### PR TITLE
Add wiki sync script and refresh item datasets

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "validate:data": "node --loader ts-node/esm scripts/validate-data.ts",
+    "sync:data": "node --loader ts-node/esm scripts/sync-cargo-data.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {

--- a/scripts/sync-cargo-data.ts
+++ b/scripts/sync-cargo-data.ts
@@ -1,0 +1,355 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const execFileAsync = promisify(execFile)
+
+const WIKI_BASE = 'https://nomanssky.fandom.com'
+const DATA_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/data')
+
+const slugify = (name: string): string =>
+  name
+    .toLowerCase()
+    .replace(/['’]/g, '')
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+
+const parseNumber = (value: unknown): number => {
+  if (value === null || value === undefined) return 0
+  if (typeof value === 'number') return value
+  if (typeof value === 'string') {
+    const sanitized = value.replace(/[, ]/g, '')
+    const parsed = Number.parseFloat(sanitized)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}
+
+const fetchJson = async <T>(url: string): Promise<T> => {
+  const { stdout } = await execFileAsync('curl', ['-sS', url])
+  try {
+    return JSON.parse(stdout) as T
+  } catch (error) {
+    throw new Error(`Failed to parse response from ${url}: ${(error as Error).message}\n${stdout.slice(0, 200)}`)
+  }
+}
+
+type CargoQueryResponse<T> = {
+  cargoquery?: Array<{ title: T }>
+}
+
+type ItemRow = {
+  pageName: string
+  value: unknown
+  category: string | null
+  type: string | null
+  itemType: string | null
+}
+
+type ItemEntry = { id: string; name: string; group: string; value: number }
+
+const fetchItems = async () => {
+  const limit = 500
+  let offset = 0
+  const items = new Map<string, ItemEntry>()
+
+  while (true) {
+    const query = new URLSearchParams({
+      action: 'cargoquery',
+      format: 'json',
+      tables: 'Items',
+      fields:
+        'Items._pageName=pageName,Items.Total_Value=value,Items.Category=category,Items.Type=type,Items.Item_type=itemType',
+      limit: limit.toString(),
+      offset: offset.toString()
+    })
+    const url = `${WIKI_BASE}/api.php?${query.toString()}`
+    const data = await fetchJson<CargoQueryResponse<ItemRow>>(url)
+    const rows = data.cargoquery ?? []
+    if (rows.length === 0) break
+
+    rows.forEach(({ title }) => {
+      const name = title.pageName
+      const id = slugify(name)
+      if (!id) return
+      const groupSource = title.itemType ?? title.category ?? title.type ?? 'Unknown'
+      const group = slugify(groupSource) || 'unknown'
+      const value = parseNumber(title.value)
+      items.set(id, { id, name, group, value })
+    })
+
+    offset += limit
+  }
+
+  return items
+}
+
+type CargoExportRow = Record<string, unknown>
+
+const fetchCargoExport = async (table: string, fields: string[]): Promise<CargoExportRow[]> => {
+  const limit = 500
+  let offset = 0
+  const results: CargoExportRow[] = []
+  while (true) {
+    const query = new URLSearchParams({
+      tables: table,
+      fields: fields.join(','),
+      format: 'json',
+      limit: limit.toString(),
+      offset: offset.toString()
+    })
+    const url = `${WIKI_BASE}/wiki/Special:CargoExport?${query.toString()}`
+    const rows = await fetchJson<CargoExportRow[]>(url)
+    if (rows.length === 0) break
+    results.push(...rows)
+    offset += limit
+  }
+  return results
+}
+
+type RefinerRow = {
+  _pageName: string
+  Recipe: string
+  Output: unknown
+  TimeProcessing: unknown
+  Resources?: string[]
+  ResourceQtys?: string[]
+}
+
+type ParsedInput = { item: string; qty: number; label: string }
+type RecipeInput = { item: string; qty: number }
+
+type RefinerRecipe = {
+  id: string
+  name: string
+  inputs: RecipeInput[]
+  output: { item: string; qty: number }
+  timeSeconds: number
+}
+
+const parseInputs = (resources?: string[], quantities?: string[]): ParsedInput[] => {
+  if (!resources || resources.length === 0) return []
+  return resources
+    .map((resource, index) => {
+      const cleaned = resource.trim()
+      if (!cleaned) return null
+      const qtyEntry = quantities?.[index] ?? ''
+      const [, qtyRaw = '1'] = qtyEntry.split(';').map((part) => part.trim())
+      const qty = parseNumber(qtyRaw)
+      return { item: slugify(cleaned), qty, label: cleaned }
+    })
+    .filter((entry): entry is ParsedInput => !!entry && entry.qty > 0 && entry.item.length > 0)
+}
+
+const fetchRefiner = async (): Promise<{ recipes: RefinerRecipe[]; ingredients: ParsedInput[]; outputs: Array<{ id: string; label: string }> }> => {
+  const rows = await fetchCargoExport('PoC_Refining', [
+    '_pageName',
+    'Recipe',
+    'Output',
+    'TimeProcessing',
+    'Resources',
+    'ResourceQtys'
+  ])
+
+  const ingredients: ParsedInput[] = []
+  const outputs: Array<{ id: string; label: string }> = []
+
+  const recipes = rows
+    .map((row) => row as RefinerRow)
+    .map((row, index) => {
+      const parsedInputs = parseInputs(row.Resources, row.ResourceQtys)
+      ingredients.push(...parsedInputs)
+      const outputQty = parseNumber(row.Output) || 1
+      const timeSeconds = Math.round(parseNumber(row.TimeProcessing) * 60) || 1
+      const outputId = slugify(row._pageName)
+      outputs.push({ id: outputId, label: row._pageName })
+      const idBase = slugify(`${row.Recipe || row._pageName}_${parsedInputs.map((input) => input.item).join('_')}`)
+      const id = idBase ? `${idBase}_${index}` : `refiner_${index}`
+      return {
+        id,
+        name: row.Recipe || row._pageName,
+        inputs: parsedInputs.map(({ item, qty }) => ({ item, qty })),
+        output: { item: outputId, qty: outputQty },
+        timeSeconds
+      }
+    })
+    .filter((recipe) => recipe.inputs.length > 0)
+
+  return { recipes, ingredients, outputs }
+}
+
+type CookingRow = {
+  _pageName: string
+  Recipe: string
+  Output: unknown
+  Resources?: string[]
+  ResourceQtys?: string[]
+}
+
+type CookingRecipe = {
+  id: string
+  name: string
+  inputs: RecipeInput[]
+  output: { item: string; qty: number }
+  heated: boolean
+  refined: boolean
+  mixed: boolean
+}
+
+const fetchCooking = async (): Promise<{ recipes: CookingRecipe[]; ingredients: ParsedInput[]; outputs: Array<{ id: string; label: string }> }> => {
+  const rows = await fetchCargoExport('PoC_Cooking', [
+    '_pageName',
+    'Recipe',
+    'Output',
+    'Resources',
+    'ResourceQtys'
+  ])
+
+  const ingredients: ParsedInput[] = []
+  const outputs: Array<{ id: string; label: string }> = []
+
+  const recipes = rows
+    .map((row) => row as CookingRow)
+    .map((row, index) => {
+      const parsedInputs = parseInputs(row.Resources, row.ResourceQtys)
+      ingredients.push(...parsedInputs)
+      const outputQty = parseNumber(row.Output) || 1
+      const idBase = slugify(`${row.Recipe}_${row._pageName}`)
+      const id = idBase ? `${idBase}_${index}` : `cooking_${index}`
+      const outputId = slugify(row._pageName)
+      outputs.push({ id: outputId, label: row._pageName })
+      return {
+        id,
+        name: row.Recipe || row._pageName,
+        inputs: parsedInputs.map(({ item, qty }) => ({ item, qty })),
+        output: { item: outputId, qty: outputQty },
+        heated: false,
+        refined: false,
+        mixed: false
+      }
+    })
+    .filter((recipe) => recipe.inputs.length > 0)
+
+  return { recipes, ingredients, outputs }
+}
+
+type TechRow = {
+  pageName: string
+  value: unknown
+  techCategory: string | null
+  techSubcategory: string | null
+}
+
+type TechModule = {
+  id: string
+  name: string
+  platform: string
+  slotType: string
+  baseValue: number
+  adjacency: Record<string, number>
+  superchargeMultiplier: number
+  tags: string[]
+}
+
+const fetchTechnology = async (): Promise<{ modules: TechModule[]; outputs: Array<{ id: string; label: string; value: number }> }> => {
+  const limit = 500
+  let offset = 0
+  const modules: TechModule[] = []
+  const outputs: Array<{ id: string; label: string; value: number }> = []
+  while (true) {
+    const params = new URLSearchParams({
+      action: 'cargoquery',
+      format: 'json',
+      tables: 'Items',
+      fields:
+        'Items._pageName=pageName,Items.Total_Value=value,Items.Technology_category=techCategory,Items.Technology_subcategory=techSubcategory',
+      where: 'Items.Item_type="Technology"',
+      limit: limit.toString(),
+      offset: offset.toString()
+    })
+    const url = `${WIKI_BASE}/api.php?${params.toString()}`
+    const data = await fetchJson<CargoQueryResponse<TechRow>>(url)
+    const rows = data.cargoquery ?? []
+    if (rows.length === 0) break
+    for (const { title } of rows) {
+      const id = slugify(title.pageName)
+      if (!id) continue
+      const platform = slugify(title.techCategory ?? 'general') || 'general'
+      const tags = [title.techCategory, title.techSubcategory]
+        .filter((value): value is string => !!value)
+        .map((value) => slugify(value))
+        .filter(Boolean)
+      const baseValue = parseNumber(title.value) || 1
+      outputs.push({ id, label: title.pageName, value: baseValue })
+      modules.push({
+        id,
+        name: title.pageName,
+        platform,
+        slotType: 'tech',
+        baseValue,
+        adjacency: {},
+        superchargeMultiplier: 1,
+        tags
+      })
+    }
+    offset += limit
+  }
+  const deduped = new Map<string, TechModule>()
+  modules.forEach((module) => deduped.set(module.id, module))
+  const sorted = Array.from(deduped.values()).sort((a, b) => a.name.localeCompare(b.name))
+  return { modules: sorted, outputs }
+}
+
+const writeJson = async (file: string, data: unknown) => {
+  const target = path.join(DATA_DIR, file)
+  await fs.writeFile(target, `${JSON.stringify(data, null, 2)}\n`, 'utf8')
+}
+
+const main = async () => {
+  console.log('Fetching items…')
+  const items = await fetchItems()
+
+  console.log('Fetching refiner recipes…')
+  const refiner = await fetchRefiner()
+  await writeJson('refiner.json', refiner.recipes)
+  console.log(`Refiner recipes written (${refiner.recipes.length})`)
+
+  console.log('Fetching cooking recipes…')
+  const cooking = await fetchCooking()
+  await writeJson('cooking.json', cooking.recipes)
+  console.log(`Cooking recipes written (${cooking.recipes.length})`)
+
+  console.log('Fetching technology modules…')
+  const tech = await fetchTechnology()
+  await writeJson('tech.json', tech.modules)
+  console.log(`Technology modules written (${tech.modules.length})`)
+
+  const ensureItem = (id: string, label: string, valueOverride?: number) => {
+    if (!id) return
+    if (items.has(id)) return
+    items.set(id, {
+      id,
+      name: label,
+      group: 'unknown',
+      value: valueOverride ?? 0
+    })
+  }
+
+  refiner.ingredients.forEach(({ item, label }) => ensureItem(item, label))
+  refiner.outputs.forEach(({ id, label }) => ensureItem(id, label))
+  cooking.ingredients.forEach(({ item, label }) => ensureItem(item, label))
+  cooking.outputs.forEach(({ id, label }) => ensureItem(id, label))
+  tech.outputs.forEach(({ id, label, value }) => ensureItem(id, label, value))
+
+  const sortedItems = Array.from(items.values()).sort((a, b) => a.name.localeCompare(b.name))
+  await writeJson('items.json', sortedItems)
+  console.log(`Items written (${sortedItems.length})`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/src/data/cooking.json
+++ b/src/data/cooking.json
@@ -1,37 +1,26038 @@
 [
   {
-    "id": "creamy_sauce_recipe",
-    "name": "Creamy Sauce",
+    "id": "assemble_baked_product_apple_cake_of_lost_souls_0",
+    "name": "Assemble Baked Product",
     "inputs": [
-      {"item": "fresh_milk", "qty": 1},
-      {"item": "nutrient_paste", "qty": 1}
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
     ],
-    "output": {"item": "creamy_sauce", "qty": 1},
+    "output": {
+      "item": "apple_cake_of_lost_souls",
+      "qty": 1
+    },
     "heated": false,
-    "refined": true,
-    "mixed": true
-  },
-  {
-    "id": "processed_meat_recipe",
-    "name": "Processed Meat",
-    "inputs": [
-      {"item": "meaty_chunks", "qty": 1}
-    ],
-    "output": {"item": "processed_meat", "qty": 1},
-    "heated": true,
     "refined": false,
     "mixed": false
   },
   {
-    "id": "mystery_meat_stew_recipe",
-    "name": "Mystery Meat Stew",
+    "id": "assemble_baked_product_apple_cake_of_lost_souls_1",
+    "name": "Assemble Baked Product",
     "inputs": [
-      {"item": "processed_meat", "qty": 1},
-      {"item": "creamy_sauce", "qty": 1}
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
     ],
-    "output": {"item": "mystery_meat_stew", "qty": 1},
-    "heated": true,
+    "output": {
+      "item": "apple_cake_of_lost_souls",
+      "qty": 1
+    },
+    "heated": false,
     "refined": false,
-    "mixed": true
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_apple_cake_of_lost_souls_2",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_cake_of_lost_souls",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_apple_curiosity_3",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_apple_curiosity_4",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_apple_curiosity_5",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_apple_ice_cream_6",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_apple_ice_cream_7",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_apple_ice_cream_8",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_apple_ice_cream_9",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_apple_ice_cream_10",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_apple_ice_cream_11",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_apple_ice_cream_12",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_apple_ice_cream_13",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_apple_roll_14",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_roll",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_apple_roll_15",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "apple_roll",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_legs_in_pastry_16",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "leg_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "legs_in_pastry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_abyssal_stew_17",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_abyssal_stew_18",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_19",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "bone_nuggets",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_20",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_21",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_22",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_23",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_24",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_25",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_26",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_27",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_28",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_29",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_30",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_31",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_32",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_33",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_34",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_35",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "nourishing_slime",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_36",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_37",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_38",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_39",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_40",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_41",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_42",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_43",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_44",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_45",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_46",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_47",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_48",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_49",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "bone_nuggets",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_50",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_51",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_52",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_53",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_54",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_55",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_56",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_57",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_58",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_59",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_60",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_61",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_62",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_63",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_64",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "nourishing_slime",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_65",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_66",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_67",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_68",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_69",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_70",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_71",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_72",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_73",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_74",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_75",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_76",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_abyssal_stew_77",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "abyssal_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_ambrosial_curse_78",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "butter_syrup",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ambrosial_curse",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_ambrosial_curse_79",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ambrosial_curse",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_ambrosial_wonder_80",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ambrosial_wonder",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_angelic_fruitcake_81",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "angelic_fruitcake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_angelic_fruitcake_82",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "angelic_fruitcake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_angelic_fruitcake_83",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "angelic_fruitcake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_anomalous_doughnut_84",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "anomalous_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_fruit_anomalous_jam_85",
+    "name": "Preserve Fruit",
+    "inputs": [
+      {
+        "item": "hexaberry",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "anomalous_jam",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_anomalous_tart_86",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "anomalous_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_anomalous_tart_87",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "hexaberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "anomalous_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_appalling_jam_sponge_88",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "appalling_jam_sponge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_appalling_jam_sponge_89",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "appalling_jam_sponge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_appalling_jam_sponge_90",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "appalling_jam_sponge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_appalling_jam_sponge_91",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "appalling_jam_sponge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_baked_anomaly_92",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "baked_anomaly",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_baked_anomaly_93",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "hexaberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "baked_anomaly",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_baked_anomaly_94",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "silicon_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "baked_anomaly",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_baked_cheese_tart_95",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "baked_cheese_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_baked_cheese_tart_96",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "baked_cheese_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_baked_cheese_tart_97",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "baked_cheese_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_baked_eggs_98",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "creature_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "baked_eggs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_baked_eggs_99",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "giant_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "baked_eggs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_baked_eggs_100",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "larval_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "baked_eggs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_baked_eggs_101",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "baked_eggs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "extract_nutrients_bittersweet_cocoa_102",
+    "name": "Extract Nutrients",
+    "inputs": [
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bittersweet_cocoa",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_bone_butter_103",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bone_butter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_bone_cream_104",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "bone_milk",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bone_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_bone_cream_cheese_105",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "bone_cream",
+        "qty": 1
+      },
+      {
+        "item": "wild_yeast",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bone_cream_cheese",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_bone_milk_106",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "bone_nuggets",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bone_milk",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_bread_107",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "dough",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bread",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_brined_flesh_108",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "frostbite_ray",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "brined_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_brined_flesh_109",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "giant_witchfin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "brined_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_brined_flesh_110",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "magma_shark",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "brined_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_brined_flesh_111",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "marrow_shark",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "brined_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_brined_flesh_112",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "ossified_deinosuchus",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "brined_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_brined_flesh_113",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "radiant_sunfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "brined_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_brined_flesh_114",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "shrieking_venttail",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "brined_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_brined_flesh_115",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "twilight_cavefish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "brined_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_brined_flesh_116",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "whispering_bonefish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "brined_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_briney_delight_117",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "salty_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "briney_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_briney_rime_118",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "salty_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "briney_rime",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_briney_rime_119",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "salty_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "briney_rime",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_bugs_in_a_blanket_120",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "creature_egg",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bugs_in_a_blanket",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_bugs_in_a_blanket_121",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "creature_egg",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bugs_in_a_blanket",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_bugs_in_a_blanket_122",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "creature_egg",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bugs_in_a_blanket",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_bugs_in_a_blanket_123",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "giant_egg",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bugs_in_a_blanket",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_bugs_in_a_blanket_124",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "giant_egg",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bugs_in_a_blanket",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_bugs_in_a_blanket_125",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "giant_egg",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bugs_in_a_blanket",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_bugs_in_a_blanket_126",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "omelette",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bugs_in_a_blanket",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_bugs_in_a_blanket_127",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "scrambled_marrow",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bugs_in_a_blanket",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_bugs_in_a_blanket_128",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bugs_in_a_blanket",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_bugs_in_a_blanket_129",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bugs_in_a_blanket",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_bugs_in_a_blanket_130",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "bugs_in_a_blanket",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_burning_jam_fluffer_131",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "burning_jam_fluffer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_burning_jam_fluffer_132",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "burning_jam_fluffer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_burning_jam_surprise_133",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "burning_jam_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_burning_jam_surprise_134",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "burning_jam_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_burning_surprise_135",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "burning_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_burning_surprise_136",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "fire_water",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "burning_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_burning_surprise_137",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "fireberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "burning_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_butter_syrup_138",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "bone_butter",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "butter_syrup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_butter_syrup_139",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "churned_butter",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "butter_syrup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_fruit_cactus_jelly_140",
+    "name": "Preserve Fruit",
+    "inputs": [
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cactus_jelly",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "extract_nutrients_cactus_nectar_141",
+    "name": "Extract Nutrients",
+    "inputs": [
+      {
+        "item": "cactus_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cactus_nectar",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_cake_batter_142",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "honey_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "creature_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_cake_batter_143",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "honey_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "giant_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_cake_batter_144",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "honey_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_cake_batter_145",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "sweetened_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "creature_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_cake_batter_146",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "sweetened_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "giant_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_cake_batter_147",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "sweetened_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_burning_dread_148",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_burning_dread",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_burning_dread_149",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_burning_dread",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_eternal_sleep_150",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "monstrous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_eternal_sleep",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_eternal_sleep_151",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "butter_syrup",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_eternal_sleep",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_eternal_sleep_152",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_eternal_sleep",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_glass_153",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_glass",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_glass_154",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_glass",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_sin_155",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_sin",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_sin_156",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_sin",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_sin_157",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_sin",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_the_lost_158",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "monstrous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_the_lost",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_the_lost_159",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "salty_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_the_lost",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_the_lost_160",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "stellar_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_the_lost",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_the_lost_161",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_the_lost",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cake_of_the_lost_162",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cake_of_the_lost",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_candied_apples_163",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "candied_apples",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_candied_apples_164",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "candied_apples",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_candied_apples_165",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "candied_apples",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_caramel_curiosity_166",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "caramel_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_caramel_doughnut_167",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "caramel_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_caramel_ice_cream_168",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "caramel_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_caramel_ice_cream_169",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "caramel_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_caramel_ice_cream_170",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "caramel_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_caramel_ice_cream_171",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "caramel_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_caramel_tart_172",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "caramel_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_caramel_encrusted_cake_173",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "caramel_encrusted_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_caramelised_nightmare_174",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "caramelised_nightmare",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "not_recommended_carbon_nanotubes_175",
+    "name": "NOT RECOMMENDED",
+    "inputs": [
+      {
+        "item": "chewy_wires",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "carbon_nanotubes",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_cheese_and_flesh_stew_176",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "mystery_meat_stew",
+        "qty": 1
+      },
+      {
+        "item": "partially_liquid_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheese_and_flesh_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_cheese_and_flesh_stew_177",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "soiled_soup",
+        "qty": 1
+      },
+      {
+        "item": "partially_liquid_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheese_and_flesh_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_cheese_and_flesh_stew_178",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "well_stirred_stew",
+        "qty": 1
+      },
+      {
+        "item": "partially_liquid_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheese_and_flesh_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_179",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      },
+      {
+        "item": "aloe_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_180",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_181",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_182",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_183",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_184",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      },
+      {
+        "item": "aloe_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_185",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_186",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_187",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_188",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_189",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      },
+      {
+        "item": "aloe_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_190",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_191",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_192",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cheesy_vegetable_pie_193",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cheesy_vegetable_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_194",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_195",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_196",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "fiendish_roe",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_197",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_198",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "leg_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_199",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_200",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_201",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_202",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_203",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_204",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_205",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_206",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "salty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_207",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_208",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_chewy_dumpling_stew_209",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_dumpling_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_chewy_biscuit_210",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "nourishing_slime",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_chewy_biscuit_211",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_chewy_organ_pie_212",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_organ_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_chewy_organ_pie_213",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_organ_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_chewy_organ_pie_214",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chewy_organ_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_chocolate_cake_215",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chocolate_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_chocolate_curiosity_216",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chocolate_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_chocolate_dream_217",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chocolate_dream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_chocolate_ice_cream_218",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chocolate_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_chocolate_ice_cream_219",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chocolate_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_chocolate_ice_cream_220",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chocolate_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_chocolate_ice_cream_221",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chocolate_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_chocolate_oozer_222",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chocolate_oozer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_choking_monstrosity_cake_223",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "choking_monstrosity_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_choking_monstrosity_cake_224",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "choking_monstrosity_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_choking_monstrosity_cake_225",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "choking_monstrosity_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_churned_butter_226",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "churned_butter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_clarified_oil_227",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "bone_butter",
+        "qty": 1
+      },
+      {
+        "item": "bone_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "clarified_oil",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_clarified_oil_228",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "bone_butter",
+        "qty": 1
+      },
+      {
+        "item": "proto_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "clarified_oil",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_clarified_oil_229",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "churned_butter",
+        "qty": 1
+      },
+      {
+        "item": "bone_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "clarified_oil",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_clarified_oil_230",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "churned_butter",
+        "qty": 1
+      },
+      {
+        "item": "churned_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "clarified_oil",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_clarified_oil_231",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "churned_butter",
+        "qty": 1
+      },
+      {
+        "item": "proto_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "clarified_oil",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_cocoa_creams_232",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cocoa_creams",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_cocoa_doughnut_233",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cocoa_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_cocoa_tart_234",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cocoa_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_cough_biscuits_235",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cough_biscuits",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_cough_biscuits_236",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cough_biscuits",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_cough_biscuits_237",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "glass_grains",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cough_biscuits",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_cough_biscuits_238",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "leopard_fruit",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cough_biscuits",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_cream_239",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "fresh_milk",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_cream_240",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "wild_milk",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cream_buns_241",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream_buns",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cream_buns_242",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream_buns",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cream_curiosity_243",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_cream_curiosity_244",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_cream_fingers_245",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream_fingers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_cream_fingers_246",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream_fingers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_cream_fingers_247",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "monstrous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream_fingers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_cream_fingers_248",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "proto_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream_fingers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_cream_fingers_249",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "salty_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream_fingers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_cream_fingers_250",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "stellar_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream_fingers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_cream_fingers_251",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream_fingers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_cream_of_vegetable_soup_252",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "fibrous_stew",
+        "qty": 1
+      },
+      {
+        "item": "creamy_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cream_of_vegetable_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_creamed_organ_soup_253",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "chewy_dumpling_stew",
+        "qty": 1
+      },
+      {
+        "item": "creamy_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamed_organ_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_creamed_organ_soup_254",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystalline_soup",
+        "qty": 1
+      },
+      {
+        "item": "creamy_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamed_organ_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_creamed_organ_soup_255",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "gelatinous_goop",
+        "qty": 1
+      },
+      {
+        "item": "creamy_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamed_organ_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_creamed_organ_soup_256",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "stewed_organs",
+        "qty": 1
+      },
+      {
+        "item": "creamy_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamed_organ_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_creamy_clouds_of_nectar_257",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamy_clouds_of_nectar",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_creamy_clouds_of_nectar_258",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamy_clouds_of_nectar",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_creamy_sauce_259",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "bone_cream",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamy_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_creamy_sauce_260",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "cream",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamy_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_creamy_sauce_261",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "cream",
+        "qty": 1
+      },
+      {
+        "item": "proto_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamy_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_creamy_sauce_262",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "proto_cream",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamy_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_creamy_sauce_263",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "proto_cream",
+        "qty": 1
+      },
+      {
+        "item": "proto_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamy_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_creamy_treat_264",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamy_treat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_creamy_treat_265",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creamy_treat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_266",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_267",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "aloe_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_268",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "cactus_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_269",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_270",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "fireberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_271",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_272",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_273",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "fungal_mould",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_274",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "gamma_root",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_275",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "glass_grains",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_276",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "grahberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_277",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "heptaploid_wheat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_278",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "hexaberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_279",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_280",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_281",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "marrow_bulb",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_282",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_283",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "pilgrimberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_284",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_285",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_286",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "solanium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_287",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_288",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "star_bulb",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_289",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_290",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "carbon_nanotubes",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_291",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_292",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_293",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "leg_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_294",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_295",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_296",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_297",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_creature_pellets_298",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "creature_pellets",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_crunchy_caramel_299",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      },
+      {
+        "item": "salt",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crunchy_caramel",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_crunchy_caramel_300",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "root_juice",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crunchy_caramel",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_301",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_302",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_303",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_304",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "fiendish_roe",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_305",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_306",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "leg_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_307",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_308",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_309",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_310",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_311",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_312",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_313",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "salty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_314",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_315",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_crystalline_soup_316",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystalline_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_curdy_cracker_317",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "curdy_cracker",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_curdy_cracker_318",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "partially_liquid_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "curdy_cracker",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_curdy_cracker_319",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "curdy_cracker",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_curdy_cracker_320",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "curdy_cracker",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_custard_curiosity_321",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "custard_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_custard_curiosity_322",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "custard_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_custard_doughnut_323",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "custard_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_custard_doughnut_324",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "custard_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_custard_fancy_325",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "custard_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_custard_fancy_326",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "custard_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_custard_tart_327",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "salty_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "custard_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_custard_tart_328",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "custard_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_custard_tart_329",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "custard_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_deathly_cold_ice_cream_330",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "monstrous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "deathly_cold_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_deathly_cold_ice_cream_331",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "monstrous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "deathly_cold_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_delicate_meringue_332",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "creature_egg",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "delicate_meringue",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_delicate_meringue_333",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "giant_egg",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "delicate_meringue",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_delicate_meringue_334",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "larval_core",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "delicate_meringue",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_delicate_meringue_335",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "delicate_meringue",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_delicious_vegetable_stew_336",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "fibrous_stew",
+        "qty": 1
+      },
+      {
+        "item": "flavoursome_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "delicious_vegetable_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_devilled_organs_337",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "chewy_dumpling_stew",
+        "qty": 1
+      },
+      {
+        "item": "scorching_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "devilled_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_devilled_organs_338",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystalline_soup",
+        "qty": 1
+      },
+      {
+        "item": "scorching_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "devilled_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_devilled_organs_339",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "gelatinous_goop",
+        "qty": 1
+      },
+      {
+        "item": "scorching_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "devilled_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_devilled_organs_340",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "stewed_organs",
+        "qty": 1
+      },
+      {
+        "item": "scorching_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "devilled_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_doomed_cream_cake_341",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "doomed_cream_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_doomed_cream_cake_342",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "doomed_cream_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_dough_343",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "wild_yeast",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "dough",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_earthy_pie_344",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "earthy_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_edible_chum_345",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "brineskipper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "edible_chum",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_edible_chum_346",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "immortal_flatfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "edible_chum",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_edible_chum_347",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "inverted_snapper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "edible_chum",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_edible_chum_348",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "jungle_redfin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "edible_chum",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_edible_chum_349",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "murmurfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "edible_chum",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_edible_chum_350",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "rockfin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "edible_chum",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_edible_chum_351",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "solar_roach",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "edible_chum",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_edible_chum_352",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "sweeperfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "edible_chum",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_edible_chum_353",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "toxic_stonefish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "edible_chum",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_edible_chum_354",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "wandering_kelpfin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "edible_chum",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_enriched_biscuit_355",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "bone_milk",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "enriched_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_enriched_biscuit_356",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "bone_nuggets",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "enriched_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_enriched_biscuit_357",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "craw_milk",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "enriched_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_enriched_biscuit_358",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "creature_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "enriched_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_enriched_biscuit_359",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "fresh_milk",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "enriched_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_enriched_biscuit_360",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "giant_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "enriched_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_enriched_biscuit_361",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "enriched_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_enriched_biscuit_362",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "warm_proto_milk",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "enriched_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_enriched_biscuit_363",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "wild_milk",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "enriched_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_esophageal_surprise_364",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "esophageal_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_esophageal_surprise_365",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "esophageal_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_esophageal_surprise_366",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "esophageal_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_ever_boiling_cake_367",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ever_boiling_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_ever_boiling_cake_368",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ever_boiling_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_fruit_ever_burning_jam_369",
+    "name": "Preserve Fruit",
+    "inputs": [
+      {
+        "item": "fireberry",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ever_burning_jam",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_extra_fluffy_batter_370",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "delicate_meringue",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "creature_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "extra_fluffy_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_extra_fluffy_batter_371",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "delicate_meringue",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "giant_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "extra_fluffy_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_extra_fluffy_batter_372",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "delicate_meringue",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "extra_fluffy_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_extra_fluffy_cream_cake_373",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "extra_fluffy_cream_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_extra_fluffy_cream_cake_374",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "extra_fluffy_cream_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_375",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      },
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_376",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_377",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      },
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_378",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_379",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_380",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_381",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      },
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_382",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_383",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      },
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_384",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_385",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      },
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_386",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_387",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_388",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_389",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_390",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "jade_peas",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_391",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "jade_peas",
+        "qty": 1
+      },
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_392",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "jade_peas",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_393",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "jade_peas",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_394",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "jade_peas",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_395",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      },
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_396",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_397",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_398",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_399",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_400",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_401",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_402",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_403",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "solartillo",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_404",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "solartillo",
+        "qty": 1
+      },
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_405",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "solartillo",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_406",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "solartillo",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_407",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "solartillo",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_408",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "solartillo",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_409",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      },
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_410",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_411",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      },
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_412",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_413",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_414",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_415",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_416",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "sweetroot",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fibrous_stew_417",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "sweetroot",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fibrous_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_fiery_vegetable_stew_418",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "fibrous_stew",
+        "qty": 1
+      },
+      {
+        "item": "scorching_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fiery_vegetable_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "liquidise_fire_water_419",
+    "name": "Liquidise",
+    "inputs": [
+      {
+        "item": "fireberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fire_water",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_fish_biscuit_420",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "edible_chum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_fish_biscuit_421",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "hadal_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_fish_biscuit_422",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "salty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fish_fry_423",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "common_shimmertail",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_fry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fish_fry_424",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "fools_goldfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_fry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fish_fry_425",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "fragile_icthyoscale",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_fry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fish_fry_426",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "oilfin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_fry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fish_fry_427",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "pyrefin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_fry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fish_fry_428",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "rimescale_snapper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_fry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fish_fry_429",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "spotted_protofin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_fry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fish_fry_430",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "tiny_scuttlefish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_fry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fish_fry_431",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "venemous_triggerfin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_fry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_fish_pie_432",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "salty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fish_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_flavoursome_organs_433",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "chewy_dumpling_stew",
+        "qty": 1
+      },
+      {
+        "item": "flavoursome_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "flavoursome_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_flavoursome_organs_434",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystalline_soup",
+        "qty": 1
+      },
+      {
+        "item": "flavoursome_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "flavoursome_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_flavoursome_organs_435",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "gelatinous_goop",
+        "qty": 1
+      },
+      {
+        "item": "flavoursome_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "flavoursome_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_flavoursome_organs_436",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "stewed_organs",
+        "qty": 1
+      },
+      {
+        "item": "flavoursome_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "flavoursome_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_flavoursome_sauce_437",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "root_juice",
+        "qty": 1
+      },
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "flavoursome_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "liquidise_flavoursome_sauce_438",
+    "name": "Liquidise",
+    "inputs": [
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      },
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "flavoursome_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fleshy_cylinder_439",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "blistering_eel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fleshy_cylinder",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fleshy_cylinder_440",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "cyclonic_eel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fleshy_cylinder",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fleshy_cylinder_441",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "cyclopic_eel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fleshy_cylinder",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fleshy_cylinder_442",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "electric_eel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fleshy_cylinder",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fleshy_cylinder_443",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "flashfire_eel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fleshy_cylinder",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fleshy_cylinder_444",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "midnight_eel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fleshy_cylinder",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fleshy_cylinder_445",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "mist_serpent",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fleshy_cylinder",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fleshy_cylinder_446",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "reef_eel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fleshy_cylinder",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fleshy_cylinder_447",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "sunspot_eel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fleshy_cylinder",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fleshy_cylinder_448",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "viper_eel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fleshy_cylinder",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_fleshy_cylinder_449",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "warden_eel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fleshy_cylinder",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_floral_wafer_450",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "aloe_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "floral_wafer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_floral_wafer_451",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "grahberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "floral_wafer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_floral_wafer_452",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "marrow_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "floral_wafer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_floral_wafer_453",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "pilgrimberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "floral_wafer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_floral_wafer_454",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "solanium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "floral_wafer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_floral_wafer_455",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "star_bulb",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "floral_wafer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_floral_wafer_456",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "floral_wafer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_fluffy_caramel_delight_457",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fluffy_caramel_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_fluffy_throatripper_458",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fluffy_throatripper",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_fluffy_throatripper_459",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fluffy_throatripper",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_fluffy_throatripper_460",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fluffy_throatripper",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_frosted_mire_461",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "frosted_mire",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_frosted_mire_462",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "frosted_mire",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_463",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_464",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_465",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_466",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "leopard_fruit",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_467",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "pilgrimberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_468",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_469",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_470",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_471",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_472",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "leopard_fruit",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_473",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "pilgrimberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_474",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_475",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_476",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_477",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_478",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "leopard_fruit",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_479",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "pilgrimberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_480",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_481",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_482",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_483",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_484",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "leopard_fruit",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_485",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "pilgrimberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_fruity_ice_cream_486",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_fruity_pudding_487",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "grahberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_pudding",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_fruity_pudding_488",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "pilgrimberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fruity_pudding",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_fungal_omelette_489",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "creature_egg",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_fungal_omelette_490",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "creature_egg",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_fungal_omelette_491",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "creature_egg",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_fungal_omelette_492",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "giant_egg",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_fungal_omelette_493",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "giant_egg",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_fungal_omelette_494",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "giant_egg",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_fungal_omelette_495",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "omelette",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_fungal_omelette_496",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "scrambled_marrow",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_fungal_omelette_497",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_fungal_omelette_498",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_fungal_omelette_499",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_fungal_tart_500",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_fruit_furball_jelly_501",
+    "name": "Preserve Fruit",
+    "inputs": [
+      {
+        "item": "leopard_fruit",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "furball_jelly",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_502",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_503",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_504",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_505",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "fiendish_roe",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_506",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_507",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "leg_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_508",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_509",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_510",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_511",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_512",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_513",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_514",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "salty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_515",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_516",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_gelatinous_goop_517",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_goop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_gelatinous_membrane_518",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "flesh_rope",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_membrane",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gelatinous_sponge_519",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_sponge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gelatinous_sponge_520",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gelatinous_sponge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "extract_nutrients_glass_grains_521",
+    "name": "Extract Nutrients",
+    "inputs": [
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "glass_grains",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_glittering_honey_cake_522",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "glittering_honey_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_glowing_pie_523",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "glowing_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_glowing_pie_524",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "fireberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "glowing_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_glowing_pie_525",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "glowing_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_glowing_pie_526",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "glowing_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_gooey_butter_527",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "bone_butter",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_butter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_gooey_butter_528",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "churned_butter",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_butter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_caramel_cake_529",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_caramel_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_chocolate_cake_530",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_chocolate_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_custard_fancy_531",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_custard_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_custard_fancy_532",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_custard_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_fruit_surprise_533",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_fruit_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_fruit_surprise_534",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_fruit_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_fruit_surprise_535",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_fruit_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_honey_puff_536",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "gooey_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_honey_puff",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_honey_puff_537",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_honey_puff",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_mouthburner_538",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_mouthburner",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_mouthburner_539",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_mouthburner",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_gooey_protobutter_540",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_protobutter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_gooey_protodoughnut_541",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "gooey_protobutter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_protodoughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_screamer_542",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "monstrous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_screamer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_screamer_543",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "gooey_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_screamer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_gooey_screamer_544",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gooey_screamer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_fruit_grahjam_545",
+    "name": "Preserve Fruit",
+    "inputs": [
+      {
+        "item": "grahberry",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "grahjam",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_grilled_fillet_546",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "aberrant_duskfin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "grilled_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_grilled_fillet_547",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "bewitching_candlefish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "grilled_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_grilled_fillet_548",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "clearwater_skipper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "grilled_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_grilled_fillet_549",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "deepwater_angler",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "grilled_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_grilled_fillet_550",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "inverted_brainfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "grilled_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_grilled_fillet_551",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "longjaw_snapper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "grilled_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_grilled_fillet_552",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "mirrorscale_skipper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "grilled_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_grilled_fillet_553",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "pale_snowtail",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "grilled_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_grilled_fillet_554",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "scorpionfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "grilled_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_grilled_fillet_555",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "twisted_gulper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "grilled_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_gristle_pie_556",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gristle_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_gritty_meat_pie_557",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gritty_meat_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_ground_meat_558",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      },
+      {
+        "item": "mordite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ground_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "prepare_bait_ground_meat_559",
+    "name": "Prepare Bait",
+    "inputs": [
+      {
+        "item": "raw_steak",
+        "qty": 1
+      },
+      {
+        "item": "mordite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ground_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_haunted_chocolate_dreams_560",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "haunted_chocolate_dreams",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_haunted_fillet_561",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "the_angler",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "haunted_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_haunted_pie_562",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "fiendish_roe",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "haunted_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_haunted_wafer_563",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "fiendish_roe",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "haunted_wafer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_haunted_wafer_564",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "haunted_wafer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_haunted_wafer_565",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "larval_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "haunted_wafer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_healthy_wheatblock_566",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "healthy_wheatblock",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_healthy_wheatblock_567",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "gamma_root",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "healthy_wheatblock",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_healthy_wheatblock_568",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "heptaploid_wheat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "healthy_wheatblock",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_healthy_wheatblock_569",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "impulse_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "healthy_wheatblock",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_healthy_wheatblock_570",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "healthy_wheatblock",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_healthy_wheatblock_571",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "kelp_rice",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "healthy_wheatblock",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_healthy_wheatblock_572",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "marrow_bulb",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "healthy_wheatblock",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_healthy_wheatblock_573",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "healthy_wheatblock",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_healthy_wheatblock_574",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "healthy_wheatblock",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_healthy_wheatblock_575",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "healthy_wheatblock",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_healthy_wheatblock_576",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "healthy_wheatblock",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_herb_encrusted_flesh_577",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "mystery_meat_stew",
+        "qty": 1
+      },
+      {
+        "item": "flavoursome_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "herb_encrusted_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_herb_encrusted_flesh_578",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "soiled_soup",
+        "qty": 1
+      },
+      {
+        "item": "flavoursome_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "herb_encrusted_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_herb_encrusted_flesh_579",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "well_stirred_stew",
+        "qty": 1
+      },
+      {
+        "item": "flavoursome_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "herb_encrusted_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_herbal_crunchie_580",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "geknip",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "herbal_crunchie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_herbal_crunchie_581",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "nipnip_buds",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "herbal_crunchie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_high_fibre_pie_582",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "high_fibre_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_high_fibre_pie_583",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "steamed_vegetables",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "high_fibre_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_honey_butter_584",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "bone_butter",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_butter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_honey_butter_585",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "churned_butter",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_butter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_honey_doughnut_586",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_honey_ice_cream_587",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_honey_ice_cream_588",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_honey_ice_cream_589",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_honey_ice_cream_590",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_honey_ice_cream_591",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_honey_ice_cream_592",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_honey_ice_cream_593",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_honey_ice_cream_594",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_honey_ice_cream_595",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_honey_ice_cream_596",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_honey_ice_cream_597",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_honey_ice_cream_598",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_honey_tart_599",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_honey_tart_600",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_honey_tart_601",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_honey_waffle_602",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_waffle",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_honey_waffle_603",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_waffle",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_honey_soaked_fancy_604",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honey_soaked_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_honeybutter_doughnut_605",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "honey_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honeybutter_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_honeybutter_doughnut_606",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "honied_proto_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honeybutter_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_honeybutter_doughnut_607",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honeybutter_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_honeybutter_doughnut_608",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_proto_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honeybutter_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_honied_angel_cake_609",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honied_angel_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_honied_proto_butter_610",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honied_proto_butter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_honied_proto_cake_611",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honied_proto_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_honied_throat_sticker_612",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honied_throat_sticker",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_honied_throat_sticker_613",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honied_throat_sticker",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_honied_throat_sticker_614",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "honied_throat_sticker",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_horrifying_mush_615",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "horrifying_mush",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_horrifying_gooey_delight_616",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "monstrous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "horrifying_gooey_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_horrifying_gooey_delight_617",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "monstrous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "horrifying_gooey_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_horrifying_gooey_delight_618",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "monstrous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "horrifying_gooey_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_horrifying_gooey_delight_619",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "salty_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "horrifying_gooey_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_horrifying_gooey_delight_620",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "stellar_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "horrifying_gooey_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_horrifying_gooey_delight_621",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "horrifying_gooey_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_horrifying_gooey_delight_622",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "horrifying_gooey_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_hybrid_cake_623",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "hybrid_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_hybrid_cake_624",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "hybrid_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_hybrid_cake_625",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "hybrid_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_ice_cream_626",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_ice_cream_627",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_iced_screams_628",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "iced_screams",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_iced_screams_629",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "horrifying_mush",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "iced_screams",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_iced_screams_630",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "iced_screams",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_iced_screams_631",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "iced_screams",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_icey_marrow_632",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "icey_marrow",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_icey_marrow_633",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "icey_marrow",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_interstellar_curiosity_634",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "stellar_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "interstellar_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_interstellar_fancy_635",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "stellar_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "interstellar_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_itching_creeping_honey_sponge_636",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "gooey_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "itching_creeping_honey_sponge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_itching_creeping_honey_sponge_637",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "itching_creeping_honey_sponge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jam_curiosity_638",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jam_curiosity_639",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jam_curiosity_640",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jam_curiosity_641",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_jam_doughnut_642",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_jam_doughnut_643",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_jam_doughnut_644",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_jam_doughnut_645",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jam_fluffer_646",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_fluffer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jam_fluffer_647",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_fluffer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jam_fluffer_648",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_fluffer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jam_fluffer_649",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_fluffer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jam_oozers_650",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_oozers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jam_oozers_651",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_oozers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jam_oozers_652",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_oozers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jam_oozers_653",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_oozers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_jam_tart_654",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_jam_tart_655",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jam_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jammy_burster_656",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jammy_burster",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jammy_burster_657",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jammy_burster",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jammy_burster_658",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jammy_burster",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_jammy_burster_659",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jammy_burster",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_jammy_rounds_660",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jammy_rounds",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_jellied_eel_661",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "jellymeat",
+        "qty": 1
+      },
+      {
+        "item": "fleshy_cylinder",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jellied_eel",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_jellied_fur_tart_662",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jellied_fur_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_jellied_fur_tart_663",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "leopard_fruit",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jellied_fur_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_jellymeat_664",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "aurora_jellyfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jellymeat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_jellymeat_665",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "child_of_helios_fish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jellymeat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_jellymeat_666",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "crystal_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jellymeat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_jellymeat_667",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "glass_angel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jellymeat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_jellymeat_668",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "golden_jellyfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jellymeat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_jellymeat_669",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "jelly_of_the_veil",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jellymeat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_jellymeat_670",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "many_eyed_jellyfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jellymeat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_jellymeat_671",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "mellifluous_jellyfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jellymeat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_jellymeat_672",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "toxic_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "jellymeat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "extract_nutrients_kelp_rice_673",
+    "name": "Extract Nutrients",
+    "inputs": [
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "kelp_rice",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_leathery_tart_674",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "leathery_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "accelerated_fry_lumpen_doughnut_675",
+    "name": "Accelerated Fry",
+    "inputs": [
+      {
+        "item": "clarified_oil",
+        "qty": 1
+      },
+      {
+        "item": "dough",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "lumpen_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_pie_676",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "edible_chum",
+        "qty": 1
+      },
+      {
+        "item": "pie_case",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_pie_677",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "grilled_fillet",
+        "qty": 1
+      },
+      {
+        "item": "pie_case",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_pie_678",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "grilled_tentacles",
+        "qty": 1
+      },
+      {
+        "item": "pie_case",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_pie_679",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "marine_steak",
+        "qty": 1
+      },
+      {
+        "item": "pie_case",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_pie_680",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "mollusc_flesh",
+        "qty": 1
+      },
+      {
+        "item": "pie_case",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_pie_681",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "peeled_claws",
+        "qty": 1
+      },
+      {
+        "item": "pie_case",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_pie_682",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "pickled_fish",
+        "qty": 1
+      },
+      {
+        "item": "pie_case",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_pie_683",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "smoked_fish",
+        "qty": 1
+      },
+      {
+        "item": "pie_case",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_steak_684",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "ferrite_bowfin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_steak",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_steak_685",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "flourishing_shalefish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_steak",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_steak_686",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "frozen_knifejaw",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_steak",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_steak_687",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "fumarole_gulper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_steak",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_steak_688",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "glowing_catfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_steak",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_steak_689",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "greenscale_bloater",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_steak",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_steak_690",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "non_euclidean_flatfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_steak",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_steak_691",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "reef_guardian",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_steak",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_steak_692",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "shadowfin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_steak",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_marine_steak_693",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "venomtooth_wriggler",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marine_steak",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "extract_nutrients_marrow_flesh_694",
+    "name": "Extract Nutrients",
+    "inputs": [
+      {
+        "item": "marrow_bulb",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marrow_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "extract_nutrients_meat_flakes_695",
+    "name": "Extract Nutrients",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "meat_flakes",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_meaty_chunks_696",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "meat_flakes",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "meaty_chunks",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_mollusc_flesh_697",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "cadmium_pearlcase",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mollusc_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_mollusc_flesh_698",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "erased_clam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mollusc_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_mollusc_flesh_699",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "frostshell_clam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mollusc_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_mollusc_flesh_700",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "frozen_whelk",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mollusc_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_mollusc_flesh_701",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "hyper_cockle",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mollusc_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_mollusc_flesh_702",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "inert_whelk",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mollusc_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_mollusc_flesh_703",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "ionised_clam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mollusc_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_mollusc_flesh_704",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "ionised_oyster",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mollusc_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_mollusc_flesh_705",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "mother_of_quicksilver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mollusc_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_mollusc_flesh_706",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "pressurised_clam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mollusc_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_mollusc_flesh_707",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "shrieking_oyster",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mollusc_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_mollusc_flesh_708",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "weltscale_clam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mollusc_flesh",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_monstrous_custard_709",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "larval_core",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "monstrous_custard",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_monstrous_doughnut_710",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "monstrous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "monstrous_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_monstrous_honey_cake_711",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "monstrous_honey_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_most_curious_cake_712",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "gooey_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "most_curious_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_most_curious_cake_713",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "most_curious_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_mucal_curiosity_714",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mucal_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_mucal_curiosity_715",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mucal_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_mucal_doughnut_716",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mucal_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_muculent_tart_717",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "muculent_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_mushed_root_pie_718",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mushed_root_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_mystery_meat_pie_719",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_mystery_meat_pie_720",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_mystery_meat_pie_721",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_mystery_meat_pie_722",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_mystery_meat_pie_723",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_mystery_meat_pie_724",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_mystery_meat_pie_725",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_726",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_727",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_728",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_729",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_730",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_731",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_732",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_733",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_734",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_735",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_736",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_737",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_738",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      },
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_739",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_740",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      },
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_741",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_742",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_743",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_744",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_745",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "processed_meat",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_746",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "protosausage",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_747",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "protosausage",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_748",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "protosausage",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_749",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "protosausage",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_750",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "protosausage",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_751",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "protosausage",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_752",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "protosausage",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_753",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "raw_steak",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_754",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "raw_steak",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_755",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "raw_steak",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_756",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "raw_steak",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_757",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_758",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_759",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_760",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_761",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_762",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_763",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_764",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_765",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_766",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_767",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_768",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_mystery_meat_stew_769",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mystery_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_nectar_islands_770",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "butter_syrup",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nectar_islands",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_nectar_islands_771",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nectar_islands",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_nectar_sponge_cake_772",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "butter_syrup",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nectar_sponge_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_nectar_sponge_cake_773",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nectar_sponge_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_nightmare_sausage_774",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "gelatinous_membrane",
+        "qty": 1
+      },
+      {
+        "item": "hadal_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nightmare_sausage",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_nightmare_sausage_775",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "gelatinous_membrane",
+        "qty": 1
+      },
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nightmare_sausage",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_nightmare_sausage_776",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "gelatinous_membrane",
+        "qty": 1
+      },
+      {
+        "item": "larval_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nightmare_sausage",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "extract_nutrients_non_toxic_mushroom_777",
+    "name": "Extract Nutrients",
+    "inputs": [
+      {
+        "item": "fungal_mould",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "non_toxic_mushroom",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_nourishing_oozer_778",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nourishing_oozer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_nourishing_oozer_779",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nourishing_oozer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "liquidate_nourishing_slime_780",
+    "name": "Liquidate",
+    "inputs": [
+      {
+        "item": "juicy_grub",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nourishing_slime",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_omelette_781",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "creature_egg",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_omelette_782",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "giant_egg",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_omelette_783",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_parasitic_omelette_784",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "larval_core",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "parasitic_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_partially_liquid_cheese_785",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "bone_cream",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "partially_liquid_cheese",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_partially_liquid_cheese_786",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "bone_cream",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "partially_liquid_cheese",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_partially_liquid_cheese_787",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "cream",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "partially_liquid_cheese",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_partially_liquid_cheese_788",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "cream",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "partially_liquid_cheese",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_partially_liquid_cheese_789",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "cream",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "partially_liquid_cheese",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_partially_liquid_cheese_790",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "proto_cream",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "partially_liquid_cheese",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_partially_liquid_cheese_791",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "proto_cream",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "partially_liquid_cheese",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_partially_liquid_cheese_792",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "proto_cream",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "partially_liquid_cheese",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_pastry_793",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "bone_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pastry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_pastry_794",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "churned_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pastry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_pastry_795",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "proto_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pastry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_peeled_claws_796",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "atlantidian_crab",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "peeled_claws",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_peeled_claws_797",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "giant_hairy_crab",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "peeled_claws",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_peeled_claws_798",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "mud_crab",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "peeled_claws",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_peeled_claws_799",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "screaming_crab",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "peeled_claws",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_peeled_claws_800",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "silicate_crab",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "peeled_claws",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_peeled_claws_801",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "starshell_crab",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "peeled_claws",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_perpetual_cake_802",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_perpetual_cake_803",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_perpetual_honeycake_804",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_honeycake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_perpetual_honeycake_805",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_honeycake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_perpetual_ice_cream_806",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_perpetual_ice_cream_807",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "hexaberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_perpetual_ice_cream_808",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_perpetual_ice_cream_809",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "hexaberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_perpetual_ice_cream_810",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_perpetual_ice_cream_811",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "hexaberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_perpetual_ice_cream_812",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_perpetual_ice_cream_813",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "hexaberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_perpetual_jam_fluffer_814",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_jam_fluffer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_perpetual_jam_fluffer_815",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "perpetual_jam_fluffer",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_pickled_fish_816",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "bladdersac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pickled_fish",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_pickled_fish_817",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "bulging_snapper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pickled_fish",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_pickled_fish_818",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "frostscale_trout",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pickled_fish",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_pickled_fish_819",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "hexscale_minnow",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pickled_fish",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_pickled_fish_820",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "lamptip_ray",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pickled_fish",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_pickled_fish_821",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "needlefish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pickled_fish",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_pickled_fish_822",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "nucleic_skipper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pickled_fish",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_pickled_fish_823",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "warty_frogfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pickled_fish",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_pickled_fish_824",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "wispscale_darter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pickled_fish",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_pie_case_825",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "pastry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pie_case",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "liquidise_pilgrims_tonic_826",
+    "name": "Liquidise",
+    "inputs": [
+      {
+        "item": "pilgrimberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pilgrims_tonic",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "extract_nutrients_pilgrimberry_827",
+    "name": "Extract Nutrients",
+    "inputs": [
+      {
+        "item": "star_bulb",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pilgrimberry",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_poached_worms_828",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "all_seeing_worm",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "poached_worms",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_poached_worms_829",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "bileworm",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "poached_worms",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_poached_worms_830",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "brain_eel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "poached_worms",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_poached_worms_831",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "briny_worm",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "poached_worms",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_poached_worms_832",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "encrusted_worm",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "poached_worms",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_poached_worms_833",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "gas_worm",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "poached_worms",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_poached_worms_834",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "mandelbrot_worm",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "poached_worms",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_poached_worms_835",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "marine_glowworm",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "poached_worms",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_poached_worms_836",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "sea_cucumber",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "poached_worms",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_poached_worms_837",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "writhing_brainworm",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "poached_worms",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_pollen_puffball_838",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "butter_syrup",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pollen_puffball",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_839",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_840",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_841",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "fiendish_roe",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_842",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_843",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "leg_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_844",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_845",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_846",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_847",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_848",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_849",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_850",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "salty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_851",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_852",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_popping_stew_853",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "popping_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_prickly_curiosity_854",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "prickly_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_prickly_curiosity_855",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "prickly_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_prickly_curiosity_856",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "prickly_curiosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_primordial_sponge_857",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "primordial_sponge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_primordial_sponge_858",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "primordial_sponge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_859",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_860",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_861",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_862",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_863",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_864",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "fiendish_roe",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_865",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_866",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_867",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "leg_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_868",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_869",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_870",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_871",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_872",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_873",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_874",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_875",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "incinerate_flesh_processed_meat_876",
+    "name": "Incinerate Flesh",
+    "inputs": [
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_processed_sugar_877",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_sugar",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_processed_sugar_878",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "grahberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_sugar",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_processed_sugar_879",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "sweetroot",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "processed_sugar",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_proteinous_doughnut_880",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proteinous_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_proto_batter_881",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "honied_proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "creature_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_proto_batter_882",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "honied_proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "giant_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_proto_batter_883",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "honied_proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_proto_batter_884",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "sweetened_proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "creature_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_proto_batter_885",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "sweetened_proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "giant_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_proto_batter_886",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "sweetened_proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "accelerated_fry_proto_beignet_887",
+    "name": "Accelerated Fry",
+    "inputs": [
+      {
+        "item": "proto_oil",
+        "qty": 1
+      },
+      {
+        "item": "dough",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_beignet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_proto_butter_888",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "proto_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_butter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_proto_cream_889",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "craw_milk",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_proto_cream_890",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "warm_proto_milk",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_proto_oil_891",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "proto_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_oil",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_proto_omelette_892",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "creature_egg",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_proto_omelette_893",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "giant_egg",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_proto_omelette_894",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      },
+      {
+        "item": "protocheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_proto_sausage_pie_895",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "proto_sausage_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_protocheese_896",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "proto_cream",
+        "qty": 1
+      },
+      {
+        "item": "wild_yeast",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "protocheese",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "purge_by_fire_purged_ribs_897",
+    "name": "Purge By Fire",
+    "inputs": [
+      {
+        "item": "rancid_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "purged_ribs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_898",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "chewy_wires",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_899",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_900",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_901",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_902",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_903",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "faecium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_904",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_905",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_906",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_907",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "leg_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_908",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_909",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "meat_flakes",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_910",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_911",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_912",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "mordite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_913",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_914",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_915",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_916",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_917",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "regis_grease",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_918",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_919",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_920",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_921",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_questionable_biscuit_922",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "wild_yeast",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionable_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_questionably_sweet_cake_923",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "gooey_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionably_sweet_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_questionably_sweet_cake_924",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionably_sweet_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_questionably_sweet_cake_925",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "gooey_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionably_sweet_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_questionably_sweet_cake_926",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "questionably_sweet_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "extract_nutrients_refined_flour_927",
+    "name": "Extract Nutrients",
+    "inputs": [
+      {
+        "item": "kelp_rice",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "refined_flour",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_refined_flour_928",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "glass_grains",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "refined_flour",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_refined_flour_929",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "heptaploid_wheat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "refined_flour",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "liquidise_refreshing_drink_930",
+    "name": "Liquidise",
+    "inputs": [
+      {
+        "item": "aloe_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "refreshing_drink",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "liquidise_root_juice_931",
+    "name": "Liquidise",
+    "inputs": [
+      {
+        "item": "pulpy_roots",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "root_juice",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_salt_laced_honey_cake_932",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "salty_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "salt_laced_honey_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_salty_cruncher_933",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "salty_cruncher",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_salty_cruncher_934",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "salt",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "salty_cruncher",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_salty_custard_935",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "salt",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "salty_custard",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_salty_doughnut_936",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "salty_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "salty_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "liquidise_salty_juice_937",
+    "name": "Liquidise",
+    "inputs": [
+      {
+        "item": "cactus_flesh",
+        "qty": 1
+      },
+      {
+        "item": "salt",
+        "qty": 1
+      },
+      {
+        "item": "fire_water",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "salty_juice",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_salty_surprise_938",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "salty_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "salty_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_scorching_sauce_939",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "fire_water",
+        "qty": 1
+      },
+      {
+        "item": "fire_water",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "scorching_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_scorching_sauce_940",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "fire_water",
+        "qty": 1
+      },
+      {
+        "item": "fireberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "scorching_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_scorching_sauce_941",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "fire_water",
+        "qty": 1
+      },
+      {
+        "item": "grahberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "scorching_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_scorching_sauce_942",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "fire_water",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "scorching_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_scorching_sauce_943",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "fire_water",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "scorching_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_scorching_sauce_944",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "root_juice",
+        "qty": 1
+      },
+      {
+        "item": "fireberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "scorching_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_scorching_sauce_945",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "root_juice",
+        "qty": 1
+      },
+      {
+        "item": "grahberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "scorching_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_scorching_sauce_946",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "root_juice",
+        "qty": 1
+      },
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "scorching_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_scorching_sauce_947",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "root_juice",
+        "qty": 1
+      },
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "scorching_sauce",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_scrambled_marrow_948",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "creature_egg",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "scrambled_marrow",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_scrambled_marrow_949",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "giant_egg",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "scrambled_marrow",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_scrambled_marrow_950",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "scrambled_marrow",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seafood_stew_951",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "fishy_slab",
+        "qty": 1
+      },
+      {
+        "item": "fleshy_cylinder",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seafood_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seafood_stew_952",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "grilled_fillet",
+        "qty": 1
+      },
+      {
+        "item": "grilled_tentacle",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seafood_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seafood_stew_953",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "grilled_fillet",
+        "qty": 1
+      },
+      {
+        "item": "marine_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seafood_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seafood_stew_954",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "marine_steak",
+        "qty": 1
+      },
+      {
+        "item": "smoked_fish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seafood_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seafood_stew_955",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "peeled_claws",
+        "qty": 1
+      },
+      {
+        "item": "grilled_tentacle",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seafood_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seared_fillet_956",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "bleached_bonefish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seared_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seared_fillet_957",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "dragonfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seared_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seared_fillet_958",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "glacier_fish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seared_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seared_fillet_959",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "iceblood_gulper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seared_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seared_fillet_960",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "mantis_ray",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seared_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seared_fillet_961",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "shimmering_lashtail",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seared_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seared_fillet_962",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "sulphurfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seared_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_seared_fillet_963",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "sunspine_basker",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seared_fillet",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_seeping_pie_964",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "seeping_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_shell_puree_965",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "boiled_snapper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "shell_puree",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_shell_puree_966",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "colossal_shrimp",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "shell_puree",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_shell_puree_967",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "frozen_isopod",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "shell_puree",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_shell_puree_968",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "geno_prawn",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "shell_puree",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_shell_puree_969",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "jelly_prawn",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "shell_puree",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_shell_puree_970",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "metallic_shrimp",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "shell_puree",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "extract_nutrients_sievert_beans_971",
+    "name": "Extract Nutrients",
+    "inputs": [
+      {
+        "item": "gamma_root",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sievert_beans",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "chromatic_yolk_formation_silicon_egg_972",
+    "name": "Chromatic Yolk Formation",
+    "inputs": [
+      {
+        "item": "chromatic_metal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "silicon_egg",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "convection_heating_simple_biscuit_973",
+    "name": "Convection Heating",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "simple_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_slime_pop_974",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "slime_pop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_slime_pop_975",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "slime_pop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_slime_pop_976",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "slime_pop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_slime_pop_977",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "slime_pop",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_978",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_979",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_980",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_981",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_982",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_983",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_984",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_985",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_986",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "feline_liver",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_987",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "feline_liver",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_988",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "fiendish_roe",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_989",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "fiendish_roe",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_990",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_991",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_992",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_993",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_994",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "leg_meat",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_995",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "leg_meat",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_996",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_997",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_998",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_999",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1000",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1001",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1002",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "offal_sac",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1003",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "offal_sac",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1004",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "processed_meat",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1005",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "processed_meat",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1006",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "protosausage",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1007",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "protosausage",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1008",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "raw_steak",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1009",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "raw_steak",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1010",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1011",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1012",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1013",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1014",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_flesh_smoked_meat_1015",
+    "name": "Preserve Flesh",
+    "inputs": [
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smoked_meat",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_smokey_meat_pie_1016",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "smokey_meat_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_soft_and_spiky_surprise_1017",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soft_and_spiky_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_soft_and_spiky_surprise_1018",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soft_and_spiky_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_soft_and_spiky_surprise_1019",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soft_and_spiky_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_soft_custard_fancy_1020",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "monstrous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soft_custard_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_soft_custard_fancy_1021",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "salty_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soft_custard_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_soft_custard_fancy_1022",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "stellar_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soft_custard_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_soft_custard_fancy_1023",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soft_custard_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_soft_custard_fancy_1024",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "extra_fluffy_batter",
+        "qty": 1
+      },
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soft_custard_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "stew_bones_softened_marrow_1025",
+    "name": "Stew Bones",
+    "inputs": [
+      {
+        "item": "fossilised_biped_legs",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "softened_marrow",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "stew_bones_softened_marrow_1026",
+    "name": "Stew Bones",
+    "inputs": [
+      {
+        "item": "swift_leg_bones",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "softened_marrow",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1027",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1028",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1029",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1030",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "fiendish_roe",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1031",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1032",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "leg_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1033",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1034",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1035",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1036",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1037",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1038",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1039",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "salty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1040",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1041",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_soiled_soup_1042",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "soiled_soup",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "extract_nutrients_solartillo_1043",
+    "name": "Extract Nutrients",
+    "inputs": [
+      {
+        "item": "solanium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "solartillo",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_solidified_grease_pie_1044",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "clarified_oil",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "solidified_grease_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_solidified_grease_pie_1045",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "nourishing_slime",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "solidified_grease_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_solidified_grease_pie_1046",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "proto_oil",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "solidified_grease_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_solidified_grease_pie_1047",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "regis_grease",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "solidified_grease_pie",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_spiced_apple_cake_1048",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spiced_apple_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_spiced_apple_cake_1049",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spiced_apple_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_spiced_apple_cake_1050",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spiced_apple_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_spiced_ice_1051",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spiced_ice",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_spiced_ice_1052",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "fireberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spiced_ice",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_spiced_ice_1053",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spiced_ice",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_spiced_ice_1054",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "fireberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spiced_ice",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_spiced_ice_1055",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spiced_ice",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_spiced_ice_1056",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "fireberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spiced_ice",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_spiced_ice_1057",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spiced_ice",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_spiced_ice_1058",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "fireberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spiced_ice",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_spicy_fleshballs_1059",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "mystery_meat_stew",
+        "qty": 1
+      },
+      {
+        "item": "scorching_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spicy_fleshballs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_spicy_fleshballs_1060",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "soiled_soup",
+        "qty": 1
+      },
+      {
+        "item": "scorching_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spicy_fleshballs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_spicy_fleshballs_1061",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "well_stirred_stew",
+        "qty": 1
+      },
+      {
+        "item": "scorching_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spicy_fleshballs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_spikey_tart_1062",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "aloe_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spikey_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_spikey_tart_1063",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spikey_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_splicers_delight_1064",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "splicers_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_splicers_delight_1065",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "splicers_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_sponge_of_ambrosia_1066",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sponge_of_ambrosia",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_sponge_of_ambrosia_1067",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sponge_of_ambrosia",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_spore_dunkers_1068",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spore_dunkers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_spore_dunkers_1069",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "fungal_mould",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spore_dunkers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_spore_dunkers_1070",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "spore_dunkers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_squirming_fancy_1071",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "squirming_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_squirming_fancy_1072",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "sweetened_mucous",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "squirming_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_starbirth_delight_1073",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "stellar_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "starbirth_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_starpollen_surprise_1074",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "stellar_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "starpollen_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_startling_fancy_1075",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "startling_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_startling_fancy_1076",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "startling_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_steamed_rubber_1077",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "alpha_squid",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_rubber",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_steamed_rubber_1078",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "colossal_squid",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_rubber",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_steamed_rubber_1079",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "gamma_squid",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_rubber",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_steamed_rubber_1080",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "plasmatic_squid",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_rubber",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_steamed_rubber_1081",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "vampire_squid",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_rubber",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_steamed_rubber_1082",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "void_squid",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_rubber",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "steam_plant_matter_steamed_vegetables_1083",
+    "name": "Steam Plant Matter",
+    "inputs": [
+      {
+        "item": "foraged_mushrooms",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_vegetables",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "steam_plant_matter_steamed_vegetables_1084",
+    "name": "Steam Plant Matter",
+    "inputs": [
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_vegetables",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "steam_plant_matter_steamed_vegetables_1085",
+    "name": "Steam Plant Matter",
+    "inputs": [
+      {
+        "item": "hexaberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_vegetables",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "steam_plant_matter_steamed_vegetables_1086",
+    "name": "Steam Plant Matter",
+    "inputs": [
+      {
+        "item": "jade_peas",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_vegetables",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "steam_plant_matter_steamed_vegetables_1087",
+    "name": "Steam Plant Matter",
+    "inputs": [
+      {
+        "item": "marrow_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_vegetables",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "steam_plant_matter_steamed_vegetables_1088",
+    "name": "Steam Plant Matter",
+    "inputs": [
+      {
+        "item": "non_toxic_mushroom",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_vegetables",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "steam_plant_matter_steamed_vegetables_1089",
+    "name": "Steam Plant Matter",
+    "inputs": [
+      {
+        "item": "sievert_beans",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_vegetables",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "steam_plant_matter_steamed_vegetables_1090",
+    "name": "Steam Plant Matter",
+    "inputs": [
+      {
+        "item": "solartillo",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "steamed_vegetables",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_stellar_custard_1091",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "silicon_egg",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stellar_custard",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_stellar_custard_tart_1092",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "stellar_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stellar_custard_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_stellar_ice_cream_1093",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "stellar_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stellar_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_stellar_ice_cream_1094",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "stellar_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stellar_ice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_stewed_organs_1095",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "feline_liver",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stewed_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_stewed_organs_1096",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "offal_sac",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stewed_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_stewed_organs_1097",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "offal_sac",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stewed_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_stewed_organs_1098",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stewed_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_stewed_organs_1099",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      },
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stewed_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_stewed_organs_1100",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      },
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stewed_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_stewed_organs_1101",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stewed_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_stewed_organs_1102",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      },
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stewed_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_stewed_organs_1103",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      },
+      {
+        "item": "lumpy_brainstem",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stewed_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_stewed_organs_1104",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stewed_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_stewed_organs_1105",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      },
+      {
+        "item": "scooped_innards",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "stewed_organs",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_sticky_finger_1106",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sticky_finger",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_sugar_dough_1107",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sugar_dough",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_sweet_and_salty_puff_1108",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "salty_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sweet_and_salty_puff",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_sweet_cream_dreams_1109",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sweet_cream_dreams",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_sweet_cream_dreams_1110",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sweet_cream_dreams",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_sweetened_butter_1111",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "bone_butter",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sweetened_butter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_sweetened_butter_1112",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "churned_butter",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sweetened_butter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_fruit_sweetened_mucous_1113",
+    "name": "Preserve Fruit",
+    "inputs": [
+      {
+        "item": "nourishing_slime",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sweetened_mucous",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_sweetened_proto_butter_1114",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sweetened_proto_butter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_synthetic_honey_1115",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "synthetic_honey",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_refining_synthetic_honey_1116",
+    "name": "Nutrient Refining",
+    "inputs": [
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "synthetic_honey",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_syrup_drenched_delight_1117",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "butter_syrup",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrup_drenched_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_syrup_drenched_delight_1118",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrup_drenched_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_syrup_drenched_delight_1119",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "butter_syrup",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrup_drenched_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_syrup_drenched_delight_1120",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "gooey_butter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrup_drenched_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_syrup_drenched_delight_1121",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "sticky_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrup_drenched_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_syrup_drenched_delight_1122",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrup_drenched_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_syrup_drenched_delight_1123",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "butter_syrup",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrup_drenched_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_syrup_drenched_delight_1124",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "thick_sweet_batter",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrup_drenched_delight",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_syrupy_batter_1125",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "butter_syrup",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "creature_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrupy_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_syrupy_batter_1126",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "butter_syrup",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "giant_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrupy_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_syrupy_batter_1127",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "butter_syrup",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrupy_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_syrupy_caramel_slice_1128",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrupy_caramel_slice",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_syrupy_proto_butter_1129",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "syrupy_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrupy_proto_butter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_syrupy_tingler_1130",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrupy_tingler",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_syrupy_tingler_1131",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "ever_burning_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrupy_tingler",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_syrupy_viscera_1132",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "nightmare_sausage",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "syrupy_viscera",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_tangy_cheese_1133",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "cream",
+        "qty": 1
+      },
+      {
+        "item": "wild_yeast",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "tangy_cheese",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_tangy_organ_surprise_1134",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "chewy_dumpling_stew",
+        "qty": 1
+      },
+      {
+        "item": "partially_liquid_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "tangy_organ_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_tangy_organ_surprise_1135",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "crystalline_soup",
+        "qty": 1
+      },
+      {
+        "item": "partially_liquid_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "tangy_organ_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_tangy_organ_surprise_1136",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "gelatinous_goop",
+        "qty": 1
+      },
+      {
+        "item": "partially_liquid_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "tangy_organ_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_tangy_organ_surprise_1137",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "stewed_organs",
+        "qty": 1
+      },
+      {
+        "item": "partially_liquid_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "tangy_organ_surprise",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_tangy_vegetable_stew_1138",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "fibrous_stew",
+        "qty": 1
+      },
+      {
+        "item": "partially_liquid_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "tangy_vegetable_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_the_pie_of_knowledge_1139",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "dirty_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "the_pie_of_knowledge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_the_spawning_tart_1140",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "monstrous_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "the_spawning_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_the_stellarator_1141",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "stellar_custard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "the_stellarator",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_the_toothbreaker_1142",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "crystal_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "the_toothbreaker",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "purge_by_fire_the_worst_stew_1143",
+    "name": "Purge by Fire",
+    "inputs": [
+      {
+        "item": "juicy_grub",
+        "qty": 1
+      },
+      {
+        "item": "rancid_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "the_worst_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_thick_meat_stew_1144",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "mystery_meat_stew",
+        "qty": 1
+      },
+      {
+        "item": "creamy_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "thick_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_thick_meat_stew_1145",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "soiled_soup",
+        "qty": 1
+      },
+      {
+        "item": "creamy_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "thick_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_thick_meat_stew_1146",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "well_stirred_stew",
+        "qty": 1
+      },
+      {
+        "item": "creamy_sauce",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "thick_meat_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_thick_sweet_batter_1147",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "gooey_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "creature_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "thick_sweet_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_thick_sweet_batter_1148",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "gooey_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "giant_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "thick_sweet_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_thick_sweet_batter_1149",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "gooey_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "thick_sweet_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_thick_sweet_batter_1150",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "gooey_protobutter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "creature_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "thick_sweet_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_thick_sweet_batter_1151",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "gooey_protobutter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "giant_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "thick_sweet_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_thick_sweet_batter_1152",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "gooey_protobutter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "thick_sweet_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_tooth_pickers_1153",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "cactus_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "tooth_pickers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_tooth_pickers_1154",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "cactus_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "tooth_pickers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_tooth_pickers_1155",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "cactus_nectar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "tooth_pickers",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_tortured_honey_cake_1156",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "synthetic_honey",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "tortured_honey_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_traditional_cake_1157",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "traditional_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_traditional_cake_1158",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "traditional_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_traditional_cake_1159",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "traditional_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_traditional_cake_1160",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "cake_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "traditional_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_unbound_cream_horn_1161",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "unbound_cream_horn",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_unbound_cream_horn_1162",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "unbound_cream_horn",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_unbound_monstrosity_1163",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "unbound_monstrosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_unbound_monstrosity_1164",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "unbound_monstrosity",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_unsolvable_jam_turnover_1165",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "unsolvable_jam_turnover",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_unsolvable_jam_turnover_1166",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "proto_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "unsolvable_jam_turnover",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_very_thick_custard_1167",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "bone_cream",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      },
+      {
+        "item": "creature_egg",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "very_thick_custard",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_viscous_custard_1168",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "creature_egg",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "viscous_custard",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_viscous_custard_1169",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "giant_egg",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "viscous_custard",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_viscous_custard_1170",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "tall_eggs",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "viscous_custard",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_volatile_chocolate_fancy_1171",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "bittersweet_cocoa",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "volatile_chocolate_fancy",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_vyice_cream_1172",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "grahberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "vyice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_vyice_cream_1173",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "vyice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_vyice_cream_1174",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "grahberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "vyice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_vyice_cream_1175",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "very_thick_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "vyice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_vyice_cream_1176",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "grahberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "vyice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_vyice_cream_1177",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "vyice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_vyice_cream_1178",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "grahberry",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "vyice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "rapid_chilling_vyice_cream_1179",
+    "name": "Rapid Chilling",
+    "inputs": [
+      {
+        "item": "viscous_custard",
+        "qty": 1
+      },
+      {
+        "item": "frozen_tubers",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "vyice_cream",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_wailing_batter_1180",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "butter_syrup",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "larval_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wailing_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_wailing_batter_1181",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "gooey_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "larval_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wailing_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_wailing_batter_1182",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "gooey_protobutter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "larval_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wailing_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_wailing_batter_1183",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "honey_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "larval_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wailing_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_wailing_batter_1184",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "honied_proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "larval_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wailing_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_wailing_batter_1185",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "sweetened_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "larval_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wailing_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_wailing_batter_1186",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "sweetened_proto_butter",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "larval_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wailing_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_wailing_caramel_cake_1187",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "wailing_batter",
+        "qty": 1
+      },
+      {
+        "item": "crunchy_caramel",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wailing_caramel_cake",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_well_smoked_biscuit_1188",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_smoked_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_well_smoked_biscuit_1189",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_smoked_biscuit",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1190",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "diplo_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1191",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "feline_liver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1192",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "fiendish_roe",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1193",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "juicy_thorax",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1194",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1195",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "leg_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1196",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "meaty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1197",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "meaty_wings",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1198",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "offal_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1199",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "processed_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1200",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "protosausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1201",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "raw_steak",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1202",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "salty_chunks",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1203",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "scaly_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1204",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "smoked_meat",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "combine_and_reduce_well_stirred_stew_1205",
+    "name": "Combine and Reduce",
+    "inputs": [
+      {
+        "item": "latticed_sinew",
+        "qty": 1
+      },
+      {
+        "item": "strider_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "well_stirred_stew",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_whispering_omelette_1206",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "larval_core",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "whispering_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "bind_proteins_whispering_omelette_1207",
+    "name": "Bind Proteins",
+    "inputs": [
+      {
+        "item": "larval_core",
+        "qty": 1
+      },
+      {
+        "item": "tangy_cheese",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "whispering_omelette",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_whitebait_1208",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "common_sunfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "whitebait",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_whitebait_1209",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "fields_dartfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "whitebait",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_whitebait_1210",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "ice_darter",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "whitebait",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_whitebait_1211",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "lesser_dustfin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "whitebait",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_whitebait_1212",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "pondskipper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "whitebait",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_whitebait_1213",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "shadowfin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "whitebait",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_whitebait_1214",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "sweetwater_minnow",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "whitebait",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_whitebait_1215",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "vectorfin",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "whitebait",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "seafood_assembly_whitebait_1216",
+    "name": "Seafood Assembly",
+    "inputs": [
+      {
+        "item": "waspfish",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "whitebait",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "fermentation_wild_yeast_1217",
+    "name": "Fermentation",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wild_yeast",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "fermentation_wild_yeast_1218",
+    "name": "Fermentation",
+    "inputs": [
+      {
+        "item": "wild_yeast",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wild_yeast",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "nutrient_injection_wriggling_doughnut_1219",
+    "name": "Nutrient Injection",
+    "inputs": [
+      {
+        "item": "lumpen_doughnut",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wriggling_doughnut",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "preserve_fruit_wriggling_jam_1220",
+    "name": "Preserve Fruit",
+    "inputs": [
+      {
+        "item": "crab_apple",
+        "qty": 1
+      },
+      {
+        "item": "processed_sugar",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wriggling_jam",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_wriggling_tack_1221",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "flesh_rope",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wriggling_tack",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "dough_augmentation_wriggling_tack_1222",
+    "name": "Dough Augmentation",
+    "inputs": [
+      {
+        "item": "sugar_dough",
+        "qty": 1
+      },
+      {
+        "item": "nightmare_sausage",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wriggling_tack",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_wriggling_tart_1223",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "crab_apple",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wriggling_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_pie_wriggling_tart_1224",
+    "name": "Assemble Pie",
+    "inputs": [
+      {
+        "item": "pie_case",
+        "qty": 1
+      },
+      {
+        "item": "wriggling_jam",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "wriggling_tart",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_writhing_jam_puff_1225",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "writhing_jam_puff",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_writhing_jam_puff_1226",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "furball_jelly",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "writhing_jam_puff",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_writhing_jam_puff_1227",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "writhing_jam_puff",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_writhing_jam_puff_1228",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "writhing_roiling_batter",
+        "qty": 1
+      },
+      {
+        "item": "grahjam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "writhing_jam_puff",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "component_churn_writhing_roiling_batter_1229",
+    "name": "Component Churn",
+    "inputs": [
+      {
+        "item": "delicate_meringue",
+        "qty": 1
+      },
+      {
+        "item": "refined_flour",
+        "qty": 1
+      },
+      {
+        "item": "larval_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "writhing_roiling_batter",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_xeno_sponge_1230",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "bone_cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "xeno_sponge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
+  },
+  {
+    "id": "assemble_baked_product_xeno_sponge_1231",
+    "name": "Assemble Baked Product",
+    "inputs": [
+      {
+        "item": "syrupy_batter",
+        "qty": 1
+      },
+      {
+        "item": "anomalous_jam",
+        "qty": 1
+      },
+      {
+        "item": "cream",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "xeno_sponge",
+      "qty": 1
+    },
+    "heated": false,
+    "refined": false,
+    "mixed": false
   }
 ]

--- a/src/data/items.json
+++ b/src/data/items.json
@@ -1,21 +1,14750 @@
 [
-  {"id":"ferrite_dust","name":"Ferrite Dust","group":"minerals","value":14},
-  {"id":"pure_ferrite","name":"Pure Ferrite","group":"minerals","value":28},
-  {"id":"magnetised_ferrite","name":"Magnetised Ferrite","group":"minerals","value":62},
-  {"id":"carbon","name":"Carbon","group":"organics","value":12},
-  {"id":"condensed_carbon","name":"Condensed Carbon","group":"organics","value":24},
-  {"id":"chromatic_metal","name":"Chromatic Metal","group":"alloys","value":245},
-  {"id":"cobalt","name":"Cobalt","group":"minerals","value":198},
-  {"id":"ionised_cobalt","name":"Ionised Cobalt","group":"minerals","value":302},
-  {"id":"microprocessor","name":"Microprocessor","group":"components","value":2000},
-  {"id":"carbon_nanotubes","name":"Carbon Nanotubes","group":"components","value":550},
-  {"id":"circuit_board","name":"Circuit Board","group":"components","value":9160},
-  {"id":"sodium","name":"Sodium","group":"minerals","value":41},
-  {"id":"oxygen","name":"Oxygen","group":"organics","value":34},
-  {"id":"fresh_milk","name":"Fresh Milk","group":"cooking","value":100},
-  {"id":"processed_meat","name":"Processed Meat","group":"cooking","value":420},
-  {"id":"creamy_sauce","name":"Creamy Sauce","group":"cooking","value":420},
-  {"id":"meaty_chunks","name":"Meaty Chunks","group":"cooking","value":180},
-  {"id":"mystery_meat_stew","name":"Mystery Meat Stew","group":"cooking","value":900},
-  {"id":"nutrient_paste","name":"Nutrient Paste","group":"cooking","value":220}
+  {
+    "id": "null_figurine",
+    "name": "-null- Figurine",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "0_decal",
+    "name": "'0' Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "1_decal",
+    "name": "'1' Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "2_decal",
+    "name": "'2' Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "3_decal",
+    "name": "'3' Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "4_decal",
+    "name": "'4' Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "5_decal",
+    "name": "'5' Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "6_decal",
+    "name": "'6' Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "7_decal",
+    "name": "'7' Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "8_decal",
+    "name": "'8' Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "9_decal",
+    "name": "'9' Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "apple_cake_of_lost_souls",
+    "name": "'Apple' Cake of Lost Souls",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "apple_curiosity",
+    "name": "'Apple' Curiosity",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "apple_ice_cream",
+    "name": "'Apple' Ice Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "apple_roll",
+    "name": "'Apple' Roll",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "keen_poster",
+    "name": "'Keen Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "legs_in_pastry",
+    "name": "'Legs-in-Pastry'",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "5d_torus",
+    "name": "5D Torus",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "a_dreadful_wailing",
+    "name": "A Dreadful Wailing",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "aberrant_duskfin",
+    "name": "Aberrant Duskfin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ablative_armour",
+    "name": "Ablative Armour",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "abyssal_stew",
+    "name": "Abyssal Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ac",
+    "name": "Ac",
+    "group": "resource",
+    "value": 0
+  },
+  {
+    "id": "accelerated_fire_sigma",
+    "name": "Accelerated Fire Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "accelerated_fire_tau",
+    "name": "Accelerated Fire Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "accelerated_fire_theta",
+    "name": "Accelerated Fire Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "access_ramp",
+    "name": "Access Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "acid",
+    "name": "Acid",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "activated_cadmium",
+    "name": "Activated Cadmium",
+    "group": "resource",
+    "value": 111
+  },
+  {
+    "id": "activated_copper",
+    "name": "Activated Copper",
+    "group": "resource",
+    "value": 75
+  },
+  {
+    "id": "activated_emeril",
+    "name": "Activated Emeril",
+    "group": "resource",
+    "value": 134
+  },
+  {
+    "id": "activated_indium",
+    "name": "Activated Indium",
+    "group": "resource",
+    "value": 165
+  },
+  {
+    "id": "activated_quartzite",
+    "name": "Activated Quartzite",
+    "group": "resource",
+    "value": 165
+  },
+  {
+    "id": "active_void_egg",
+    "name": "Active Void Egg",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "adjustable_chair",
+    "name": "Adjustable Chair",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "advanced_cooling_sigma",
+    "name": "Advanced Cooling Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "advanced_cooling_tau",
+    "name": "Advanced Cooling Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "advanced_cooling_theta",
+    "name": "Advanced Cooling Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "advanced_exocraft_laser",
+    "name": "Advanced Exocraft Laser",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "advanced_ion_battery",
+    "name": "Advanced Ion Battery",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "advanced_launch_system",
+    "name": "Advanced Launch System",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "advanced_mining_laser",
+    "name": "Advanced Mining Laser",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "advanced_translator",
+    "name": "Advanced Translator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "aeration_membrane",
+    "name": "Aeration Membrane",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "aeration_membrane_next",
+    "name": "Aeration Membrane (NEXT)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "aeration_membrane_sigma",
+    "name": "Aeration Membrane Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "aeration_membrane_tau",
+    "name": "Aeration Membrane Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "aeration_membrane_theta",
+    "name": "Aeration Membrane Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "aeron_shield",
+    "name": "Aeron Shield",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "aeron_turbojet",
+    "name": "Aeron Turbojet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "agricultural_specialists_room",
+    "name": "Agricultural Specialist's Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "agricultural_terminal",
+    "name": "Agricultural Terminal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "air_filtration_unit",
+    "name": "Air Filtration Unit",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "air_purifier",
+    "name": "Air Purifier",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "airburst_engine",
+    "name": "Airburst Engine",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "albatross_cargo_tank",
+    "name": "Albatross Cargo Tank",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "albatross_sidepod",
+    "name": "Albatross Sidepod",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "albumen_pearl",
+    "name": "Albumen Pearl",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "albumen_pearl_orb",
+    "name": "Albumen Pearl Orb",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "all_seeing_worm",
+    "name": "All-Seeing Worm",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "alliance_of_galactic_travellers_banner",
+    "name": "Alliance of Galactic Travellers Banner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alliance_of_galactic_travellers_decal",
+    "name": "Alliance of Galactic Travellers Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_arch",
+    "name": "Alloy Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_door_a",
+    "name": "Alloy Door A",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_door_b",
+    "name": "Alloy Door B",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_doorway",
+    "name": "Alloy Doorway",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_floor_panel",
+    "name": "Alloy Floor Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_frontage",
+    "name": "Alloy Frontage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_half_arch",
+    "name": "Alloy Half Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_half_ramp",
+    "name": "Alloy Half Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_half_ramp_platform",
+    "name": "Alloy Half Ramp Platform",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_inner_roof_corner",
+    "name": "Alloy Inner Roof Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_power_door",
+    "name": "Alloy Power Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_ramp",
+    "name": "Alloy Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_roof_cap",
+    "name": "Alloy Roof Cap",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_roof_corner",
+    "name": "Alloy Roof Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_roof_gable",
+    "name": "Alloy Roof Gable",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_roof_panel",
+    "name": "Alloy Roof Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_triangle",
+    "name": "Alloy Triangle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_wall",
+    "name": "Alloy Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_window",
+    "name": "Alloy Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alloy_framed_glass_panel",
+    "name": "Alloy-Framed Glass Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "aloe_flesh",
+    "name": "Aloe Flesh",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alpha_squid",
+    "name": "Alpha Squid",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "alternative_landing_pad",
+    "name": "Alternative Landing Pad",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "alternator",
+    "name": "Alternator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "aluminium",
+    "name": "Aluminium",
+    "group": "resource",
+    "value": 165
+  },
+  {
+    "id": "ambassador_sublight_thruster",
+    "name": "Ambassador Sublight Thruster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ambassador_wing_module",
+    "name": "Ambassador Wing Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ambassador_class_cockpit",
+    "name": "Ambassador-Class Cockpit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ambassador_class_hab",
+    "name": "Ambassador-Class Hab",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ambassador_class_landing_bay",
+    "name": "Ambassador-Class Landing Bay",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ambassador_class_walkway",
+    "name": "Ambassador-Class Walkway",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ambrosial_curse",
+    "name": "Ambrosial Curse",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ambrosial_wonder",
+    "name": "Ambrosial Wonder",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "amino_chamber",
+    "name": "Amino Chamber",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "amino_hub_banner",
+    "name": "Amino Hub Banner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "amino_hub_decal",
+    "name": "Amino Hub Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ammonia",
+    "name": "Ammonia",
+    "group": "resource",
+    "value": 62
+  },
+  {
+    "id": "ammonium_salt",
+    "name": "Ammonium Salt",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "amplified_cartridges",
+    "name": "Amplified Cartridges",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "amplified_warp_shielding",
+    "name": "Amplified Warp Shielding",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "analysis_visor",
+    "name": "Analysis Visor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "analysis_visor_upgrade",
+    "name": "Analysis Visor Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "ancestral_memories",
+    "name": "Ancestral Memories",
+    "group": "resource",
+    "value": 1616
+  },
+  {
+    "id": "ancient_bones",
+    "name": "Ancient Bones",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ancient_conifer",
+    "name": "Ancient Conifer",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ancient_irontail",
+    "name": "Ancient Irontail",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ancient_key",
+    "name": "Ancient Key",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ancient_lock",
+    "name": "Ancient Lock",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "ancient_skeleton",
+    "name": "Ancient Skeleton",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "angelic_fruitcake",
+    "name": "Angelic Fruitcake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "angled_flat_alloy_roof",
+    "name": "Angled Flat Alloy Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "angled_flat_stone_roof",
+    "name": "Angled Flat Stone Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "angled_window",
+    "name": "Angled Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "animus_beam",
+    "name": "Animus Beam",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "anomalous_doughnut",
+    "name": "Anomalous Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "anomalous_jam",
+    "name": "Anomalous Jam",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "anomalous_tart",
+    "name": "Anomalous Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "anomaly_decal",
+    "name": "Anomaly Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "anomaly_detector",
+    "name": "Anomaly Detector",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "anomaly_suppressor",
+    "name": "Anomaly Suppressor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "antenna",
+    "name": "Antenna",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "antimatter",
+    "name": "Antimatter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "antimatter_housing",
+    "name": "Antimatter Housing",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "antimatter_reactor",
+    "name": "Antimatter Reactor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "apollo_decal",
+    "name": "Apollo Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "apollo_figurine",
+    "name": "Apollo Figurine",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "appalling_banner",
+    "name": "Appalling Banner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "appalling_jam_sponge",
+    "name": "Appalling Jam Sponge",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "appearance_modifier",
+    "name": "Appearance Modifier",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "appearance_modifier_room",
+    "name": "Appearance Modifier Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "aqua_jets",
+    "name": "Aqua-Jets",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "aquasphere",
+    "name": "AquaSphere",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "aquatic_crystal",
+    "name": "Aquatic Crystal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "aquatic_treasure",
+    "name": "Aquatic Treasure",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "arc_of_cursumburg",
+    "name": "Arc of Cursumburg",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "arcadia_aerofoil",
+    "name": "Arcadia Aerofoil",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "arcadia_blade",
+    "name": "Arcadia Blade",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "arcadia_heavy_booster",
+    "name": "Arcadia Heavy Booster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "arcadia_s_foil",
+    "name": "Arcadia S-Foil",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "arcadia_stabiliser",
+    "name": "Arcadia Stabiliser",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "arcadia_sublight_thruster",
+    "name": "Arcadia Sublight Thruster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "arcadia_wing_module",
+    "name": "Arcadia Wing Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "archaic_habitation_heater",
+    "name": "Archaic Habitation Heater",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "archive_bypass_implant",
+    "name": "Archive Bypass Implant",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "archived_soul",
+    "name": "Archived Soul",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "argonaut_aerofoil",
+    "name": "Argonaut Aerofoil",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "argonaut_cowling",
+    "name": "Argonaut Cowling",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "argonaut_fuel_cover",
+    "name": "Argonaut Fuel Cover",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "argonaut_hydraulics",
+    "name": "Argonaut Hydraulics",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "argonaut_winglet",
+    "name": "Argonaut Winglet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ariadnes_flame",
+    "name": "Ariadne's Flame",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "armadium",
+    "name": "Armadium",
+    "group": "resource",
+    "value": 27.5
+  },
+  {
+    "id": "armchair",
+    "name": "Armchair",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "armoured_suit",
+    "name": "Armoured Suit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "aronium",
+    "name": "Aronium",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "artemis_decal",
+    "name": "Artemis Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "artemis_figurine",
+    "name": "Artemis Figurine",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "artemis_translator",
+    "name": "Artemis' Translator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "artifact_chart",
+    "name": "Artifact Chart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "artifact_fragment",
+    "name": "Artifact Fragment",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ash_snail",
+    "name": "Ash Snail",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ashidaka_uyll_mark_xvi",
+    "name": "Ashidaka-Uyll Mark XVI",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "asymmetrical_timber_glass_roof",
+    "name": "Asymmetrical Timber-Glass Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "atlantid_drive",
+    "name": "Atlantid Drive",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "atlantideum",
+    "name": "Atlantideum",
+    "group": "resource",
+    "value": 138
+  },
+  {
+    "id": "atlantidian_crab",
+    "name": "Atlantidian Crab",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "atlas_decal",
+    "name": "Atlas Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "atlas_figurine",
+    "name": "Atlas Figurine",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "atlas_infinity_poster",
+    "name": "Atlas Infinity Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "atlas_race_poster",
+    "name": "Atlas Race Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "atlas_seed",
+    "name": "Atlas Seed",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "atlas_stone",
+    "name": "Atlas Stone",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "atlaspass_v1",
+    "name": "AtlasPass v1",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "atlaspass_v2",
+    "name": "AtlasPass v2",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "atlaspass_v3",
+    "name": "AtlasPass v3",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "atlaspass_v4",
+    "name": "AtlasPass V4",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "atmosphere_harvester",
+    "name": "Atmosphere Harvester",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "atmospheric_control_unit",
+    "name": "Atmospheric Control Unit",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "aurora_jellyfish",
+    "name": "Aurora Jellyfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "auto_switch",
+    "name": "Auto Switch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "automated_feeder",
+    "name": "Automated Feeder",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "automated_trap",
+    "name": "Automated Trap",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "automatic_translation_device",
+    "name": "Automatic translation device",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "autonomous_mining_unit",
+    "name": "Autonomous Mining Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "autonomous_positioning_unit",
+    "name": "Autonomous Positioning Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "azimuth_class_reactor",
+    "name": "Azimuth-Class Reactor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "baked_anomaly",
+    "name": "Baked Anomaly",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "baked_cheese_tart",
+    "name": "Baked Cheese Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "baked_eggs",
+    "name": "Baked Eggs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ballast_tank",
+    "name": "Ballast Tank",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ballistic_plating_v4",
+    "name": "Ballistic Plating V4",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "banned_weapons",
+    "name": "Banned Weapons",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "barnacle",
+    "name": "Barnacle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "barrel_fabricator",
+    "name": "Barrel Fabricator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "barrel_ioniser",
+    "name": "Barrel Ioniser",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "barricade",
+    "name": "Barricade",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "basalt",
+    "name": "Basalt",
+    "group": "resource",
+    "value": 62
+  },
+  {
+    "id": "base_computer",
+    "name": "Base Computer",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "base_salvage_capsule",
+    "name": "Base Salvage Capsule",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "base_teleport_module",
+    "name": "Base Teleport Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "battery",
+    "name": "Battery",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "beam_amplifier",
+    "name": "Beam Amplifier",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_coolant_system",
+    "name": "Beam Coolant System",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_coolant_system_sigma",
+    "name": "Beam Coolant System Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_coolant_system_tau",
+    "name": "Beam Coolant System Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_coolant_system_theta",
+    "name": "Beam Coolant System Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_focus_sigma",
+    "name": "Beam Focus Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_focus_tau",
+    "name": "Beam Focus Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_focus_theta",
+    "name": "Beam Focus Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_focus_v1",
+    "name": "Beam Focus V1",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_focus_v2",
+    "name": "Beam Focus V2",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_focus_v3",
+    "name": "Beam Focus V3",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_impact_sigma",
+    "name": "Beam Impact Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_impact_tau",
+    "name": "Beam Impact Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_impact_theta",
+    "name": "Beam Impact Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_intensifier_sigma",
+    "name": "Beam Intensifier Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_intensifier_tau",
+    "name": "Beam Intensifier Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "beam_intensifier_theta",
+    "name": "Beam Intensifier Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "bed",
+    "name": "Bed",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bewitching_cactus",
+    "name": "Bewitching Cactus",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bewitching_candlefish",
+    "name": "Bewitching Candlefish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "bileworm",
+    "name": "Bileworm",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bio_dome",
+    "name": "Bio-Dome",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bio_input_sensor",
+    "name": "Bio-Input Sensor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "bio_lantern",
+    "name": "Bio-Lantern",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "biofuel_reactor",
+    "name": "Biofuel Reactor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "biological_room_expansion",
+    "name": "Biological Room (Expansion)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "biological_sample",
+    "name": "Biological Sample",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bionic_lure",
+    "name": "Bionic Lure",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bittersweet_cocoa",
+    "name": "Bittersweet Cocoa",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "black_design_decal",
+    "name": "Black Design Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bladdersac",
+    "name": "Bladdersac",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "blaze_javelin",
+    "name": "Blaze Javelin",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "blaze_javelin_atlas",
+    "name": "Blaze Javelin (Atlas)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "blaze_javelin_coolant_sigma",
+    "name": "Blaze Javelin Coolant Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "blaze_javelin_coolant_tau",
+    "name": "Blaze Javelin Coolant Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "blaze_javelin_damage_sigma",
+    "name": "Blaze Javelin Damage Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "blaze_javelin_damage_tau",
+    "name": "Blaze Javelin Damage Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "blaze_javelin_damage_theta",
+    "name": "Blaze Javelin Damage Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "blaze_javelin_drill_array_sigma",
+    "name": "Blaze Javelin Drill Array Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "blaze_javelin_drill_array_tau",
+    "name": "Blaze Javelin Drill Array Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "blaze_javelin_drill_array_theta",
+    "name": "Blaze Javelin Drill Array Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "blaze_javelin_upgrade",
+    "name": "Blaze Javelin Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "bleached_bonefish",
+    "name": "Bleached Bonefish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "blind_titancore",
+    "name": "Blind Titancore",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "blistering_eel",
+    "name": "Blistering Eel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "blistering_mushroom",
+    "name": "Blistering Mushroom",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "blob_decal",
+    "name": "Blob Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "blood_salt",
+    "name": "Blood Salt",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bloody_organ",
+    "name": "Bloody Organ",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "blown_transistor",
+    "name": "Blown Transistor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "blue_design_decal",
+    "name": "Blue Design Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "blue_firework",
+    "name": "Blue Firework",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "blue_stripes_poster",
+    "name": "Blue Stripes Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "blueprint_analyser",
+    "name": "Blueprint Analyser",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "boiled_snapper",
+    "name": "Boiled Snapper",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "boiler_unit",
+    "name": "Boiler Unit",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "boltcaster",
+    "name": "Boltcaster",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "boltcaster_atlas",
+    "name": "Boltcaster (Atlas)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "boltcaster_clip_sigma",
+    "name": "Boltcaster Clip Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "boltcaster_clip_tau",
+    "name": "Boltcaster Clip Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "boltcaster_clip_theta",
+    "name": "Boltcaster Clip Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "boltcaster_ricochet_module",
+    "name": "Boltcaster Ricochet Module",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "boltcaster_sm",
+    "name": "Boltcaster SM",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "boltcaster_upgrade",
+    "name": "Boltcaster Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "bolted_joint",
+    "name": "Bolted Joint",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bomcdevir_mark_iv",
+    "name": "Bomcdevir Mark IV",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "bone_butter",
+    "name": "Bone Butter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bone_cream",
+    "name": "Bone Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bone_cream_cheese",
+    "name": "Bone Cream (Cheese)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bone_milk",
+    "name": "Bone Milk",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bone_nuggets",
+    "name": "Bone Nuggets",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "brain_eel",
+    "name": "Brain Eel",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "bread",
+    "name": "Bread",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "brick_pile",
+    "name": "Brick Pile",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "brined_flesh",
+    "name": "Brined Flesh",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "brineskipper",
+    "name": "Brineskipper",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "briney_delight",
+    "name": "Briney Delight",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "briney_rime",
+    "name": "Briney Rime",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "briny_worm",
+    "name": "Briny Worm",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "bromide_salt",
+    "name": "Bromide Salt",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bronze_astronaut_statue",
+    "name": "Bronze Astronaut Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bronze_atlas_statue",
+    "name": "Bronze Atlas Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bronze_blob_statue",
+    "name": "Bronze Blob Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bronze_diplo_statue",
+    "name": "Bronze Diplo Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bronze_fighter_statue",
+    "name": "Bronze Fighter Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bronze_gek_statue",
+    "name": "Bronze Gek Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bronze_walker_statue",
+    "name": "Bronze Walker Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bubble_cluster",
+    "name": "Bubble Cluster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bugs_in_a_blanket",
+    "name": "Bugs-in-a-Blanket",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bulging_snapper",
+    "name": "Bulging Snapper",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "bulkhead_door",
+    "name": "Bulkhead Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "burning_jam_fluffer",
+    "name": "Burning Jam Fluffer",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "burning_jam_surprise",
+    "name": "Burning Jam Surprise",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "burning_surprise",
+    "name": "Burning Surprise",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "burnt_out_compressor",
+    "name": "Burnt-Out Compressor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "butter_syrup",
+    "name": "Butter Syrup",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "button",
+    "name": "Button",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "buy_antimatter",
+    "name": "Buy Antimatter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bypass_chip",
+    "name": "Bypass Chip",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bytebeat_cable",
+    "name": "ByteBeat Cable",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bytebeat_device",
+    "name": "ByteBeat Device",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "bytebeat_switch",
+    "name": "Bytebeat Switch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "c28_m_fading_gleam",
+    "name": "C28/M Fading Gleam",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cable_pod",
+    "name": "Cable Pod",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cactus_flesh",
+    "name": "Cactus Flesh",
+    "group": "resource",
+    "value": 28
+  },
+  {
+    "id": "cactus_flesh_poster",
+    "name": "Cactus Flesh Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cactus_jelly",
+    "name": "Cactus Jelly",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cactus_nectar",
+    "name": "Cactus Nectar",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cadmium",
+    "name": "Cadmium",
+    "group": "resource",
+    "value": 83
+  },
+  {
+    "id": "cadmium_drive",
+    "name": "Cadmium Drive",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cadmium_pearlcase",
+    "name": "Cadmium Pearlcase",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "cadmium_starship_trail",
+    "name": "Cadmium Starship Trail",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "caf_42_banner",
+    "name": "Café 42 Banner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "caf_42_decal",
+    "name": "Café 42 Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cake_batter",
+    "name": "Cake Batter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cake_of_burning_dread",
+    "name": "Cake of Burning Dread",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cake_of_eternal_sleep",
+    "name": "Cake Of Eternal Sleep",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cake_of_glass",
+    "name": "Cake of Glass",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cake_of_sin",
+    "name": "Cake of Sin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cake_of_the_lost",
+    "name": "Cake of the Lost",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "calcishroom",
+    "name": "Calcishroom",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "calium",
+    "name": "Calium",
+    "group": "resource",
+    "value": 289
+  },
+  {
+    "id": "candelabra_bloom",
+    "name": "Candelabra Bloom",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "candied_apples",
+    "name": "Candied 'Apples'",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "canister_rack",
+    "name": "Canister Rack",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cannon_damage_sigma",
+    "name": "Cannon Damage Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cannon_damage_tau",
+    "name": "Cannon Damage Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cannon_damage_theta",
+    "name": "Cannon Damage Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "canvas_divider",
+    "name": "Canvas Divider",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "canvas_gazebo",
+    "name": "Canvas Gazebo",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "canvas_stone_roof",
+    "name": "Canvas Stone Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "capilliary_shell",
+    "name": "Capilliary Shell",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "capped_standing_light",
+    "name": "Capped Standing Light",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "captains_log",
+    "name": "Captain's Log",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "captured_nanode",
+    "name": "Captured Nanode",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "caramel_curiosity",
+    "name": "Caramel Curiosity",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "caramel_doughnut",
+    "name": "Caramel Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "caramel_ice_cream",
+    "name": "Caramel Ice Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "caramel_tart",
+    "name": "Caramel Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "caramel_encrusted_cake",
+    "name": "Caramel-Encrusted Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "caramelised_nightmare",
+    "name": "Caramelised Nightmare",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "carbon",
+    "name": "Carbon",
+    "group": "resource",
+    "value": 12
+  },
+  {
+    "id": "carbon_crystal",
+    "name": "Carbon Crystal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "carbon_nanotubes",
+    "name": "Carbon Nanotubes",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cargo_bulkhead",
+    "name": "Cargo Bulkhead",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cargo_capsule",
+    "name": "Cargo Capsule",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cargo_link",
+    "name": "Cargo Link",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cargo_pod",
+    "name": "Cargo Pod",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cargo_rack",
+    "name": "Cargo Rack",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cargo_scan_deflector",
+    "name": "Cargo Scan Deflector",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cargo_sphere",
+    "name": "Cargo Sphere",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "carite_sheet",
+    "name": "Carite Sheet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "carnivorous_bush",
+    "name": "Carnivorous Bush",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "carrier_ai_fragment",
+    "name": "Carrier AI Fragment",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cart_wheel",
+    "name": "Cart Wheel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "caustic_urchin",
+    "name": "Caustic Urchin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cb",
+    "name": "Cb",
+    "group": "resource",
+    "value": 0
+  },
+  {
+    "id": "ceiling_light",
+    "name": "Ceiling Light",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ceiling_panel",
+    "name": "Ceiling Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "celebratory_cactus",
+    "name": "Celebratory Cactus",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cement_bag",
+    "name": "Cement Bag",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cement_mixer",
+    "name": "Cement Mixer",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "certain_ulgadello_lulai",
+    "name": "Certain Ulgadello-Lulai",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "ceto_class_reactor",
+    "name": "Ceto-Class Reactor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "charge_cylinder",
+    "name": "Charge Cylinder",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cheese_and_flesh_stew",
+    "name": "Cheese-and-Flesh Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cheesy_vegetable_pie",
+    "name": "Cheesy Vegetable Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "chewy_dumpling_stew",
+    "name": "Chewy 'Dumpling' Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "chewy_biscuit",
+    "name": "Chewy Biscuit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "chewy_organ_pie",
+    "name": "Chewy Organ Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "chewy_wires",
+    "name": "Chewy Wires",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "child_of_helios_fish",
+    "name": "Child of Helios (Fish)",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "chitinous_cage",
+    "name": "Chitinous Cage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "chloride_lattice",
+    "name": "Chloride Lattice",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "chlorine",
+    "name": "Chlorine",
+    "group": "resource",
+    "value": 205
+  },
+  {
+    "id": "chloroplast_membrane",
+    "name": "Chloroplast Membrane",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "chloroplast_membrane_implant",
+    "name": "Chloroplast Membrane Implant",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "chocolate_cake",
+    "name": "Chocolate Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "chocolate_curiosity",
+    "name": "Chocolate Curiosity",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "chocolate_dream",
+    "name": "Chocolate Dream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "chocolate_ice_cream",
+    "name": "Chocolate Ice Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "chocolate_oozer",
+    "name": "Chocolate Oozer",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "choking_monstrosity_cake",
+    "name": "Choking Monstrosity Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "chromatic_metal",
+    "name": "Chromatic Metal",
+    "group": "resource",
+    "value": 88
+  },
+  {
+    "id": "chromatic_starship_trail",
+    "name": "Chromatic Starship Trail",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "chromatic_warp_shielding",
+    "name": "Chromatic Warp Shielding",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "chrysonite",
+    "name": "Chrysonite",
+    "group": "resource",
+    "value": 82.5
+  },
+  {
+    "id": "churned_butter",
+    "name": "Churned Butter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ci8_m66_vibrant_casting",
+    "name": "CI8/M66 Vibrant Casting",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "circle_window",
+    "name": "Circle Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "circle_patterned_rug",
+    "name": "Circle-Patterned Rug",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "circles_hanging_lamp",
+    "name": "Circles Hanging Lamp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "circuit_board",
+    "name": "Circuit Board",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "clarified_oil",
+    "name": "Clarified Oil",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "clarity_of_totaguri",
+    "name": "Clarity of Totaguri",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "clearwater_skipper",
+    "name": "Clearwater Skipper",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cloaking_device",
+    "name": "Cloaking Device",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cobalt",
+    "name": "Cobalt",
+    "group": "resource",
+    "value": 76
+  },
+  {
+    "id": "cobalt_mirror",
+    "name": "Cobalt Mirror",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cocoa_creams",
+    "name": "Cocoa Creams",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cocoa_doughnut",
+    "name": "Cocoa Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cocoa_tart",
+    "name": "Cocoa Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "colossal_shrimp",
+    "name": "Colossal Shrimp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "colossal_squid",
+    "name": "Colossal Squid",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "colossus_geobay",
+    "name": "Colossus Geobay",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "coloured_light",
+    "name": "Coloured Light",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "combat_amplifier_omega",
+    "name": "Combat Amplifier Omega",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "combat_amplifier_sigma",
+    "name": "Combat Amplifier Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "combat_amplifier_tau",
+    "name": "Combat Amplifier Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "combat_amplifier_theta",
+    "name": "Combat Amplifier Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "combat_scope",
+    "name": "Combat Scope",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "combat_supplies",
+    "name": "Combat Supplies",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "comet_droplets",
+    "name": "Comet Droplets",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "comforting_luovutus_purc",
+    "name": "Comforting Luovutus Purc",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "comforting_magarzello",
+    "name": "Comforting Magarzello",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "comforting_theory_x",
+    "name": "Comforting Theory X",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "common_shimmertail",
+    "name": "Common Shimmertail",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "common_sunfish",
+    "name": "Common Sunfish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "communications_station",
+    "name": "Communications Station",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "companion_egg",
+    "name": "Companion Egg",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "complete_casting_xiii",
+    "name": "Complete Casting XIII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "composter",
+    "name": "Composter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "compound_bulb",
+    "name": "Compound Bulb",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "compressed_indium_scraps",
+    "name": "Compressed Indium Scraps",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concept_of_signasin_xuccl",
+    "name": "Concept of Signasin-Xuccl",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "concrete_arch",
+    "name": "Concrete Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_door_frame",
+    "name": "Concrete Door Frame",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_doorway",
+    "name": "Concrete Doorway",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_floor_panel",
+    "name": "Concrete Floor Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_frontage",
+    "name": "Concrete Frontage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_half_arch",
+    "name": "Concrete Half Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_half_ramp",
+    "name": "Concrete Half Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_inner_roof_corner",
+    "name": "Concrete Inner Roof Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_power_door",
+    "name": "Concrete Power Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_ramp",
+    "name": "Concrete Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_roof",
+    "name": "Concrete Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_roof_corner",
+    "name": "Concrete Roof Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_roof_panel",
+    "name": "Concrete Roof Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_triangle",
+    "name": "Concrete Triangle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_wall",
+    "name": "Concrete Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_window_panel",
+    "name": "Concrete Window Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "concrete_framed_glass_panel",
+    "name": "Concrete-Framed Glass Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "condensed_carbon",
+    "name": "Condensed Carbon",
+    "group": "resource",
+    "value": 24
+  },
+  {
+    "id": "conflict_scanner",
+    "name": "Conflict Scanner",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "consciousness_bridge",
+    "name": "Consciousness Bridge",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "construction_research_unit",
+    "name": "Construction Research Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "construction_specialists_room",
+    "name": "Construction Specialist's Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "construction_terminal",
+    "name": "Construction Terminal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "containment_failure",
+    "name": "Containment Failure",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "convergence_cube",
+    "name": "Convergence Cube",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "coolant_distributor",
+    "name": "Coolant Distributor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "coolant_network",
+    "name": "Coolant Network",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "coolant_network_next",
+    "name": "Coolant Network (NEXT)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "coolant_network_sigma",
+    "name": "Coolant Network Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "coolant_network_tau",
+    "name": "Coolant Network Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "coolant_network_theta",
+    "name": "Coolant Network Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cooling_system",
+    "name": "Cooling System",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cooling_system_frigate",
+    "name": "Cooling System (Frigate)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "copper",
+    "name": "Copper",
+    "group": "resource",
+    "value": 41
+  },
+  {
+    "id": "copper_wire",
+    "name": "Copper wire",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "corner_sofa",
+    "name": "Corner Sofa",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "corner_table",
+    "name": "Corner Table",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "corroded_tanks",
+    "name": "Corroded Tanks",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "corrupt_module",
+    "name": "Corrupt Module",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cough_biscuits",
+    "name": "Cough Biscuits",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "counterfeit_circuits",
+    "name": "Counterfeit Circuits",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "covered_brick_pile",
+    "name": "Covered Brick Pile",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crab_apple",
+    "name": "Crab 'Apple'",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crate_fabricator",
+    "name": "Crate Fabricator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "craw_milk",
+    "name": "Craw Milk",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cream",
+    "name": "Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cream_buns",
+    "name": "Cream Buns",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cream_curiosity",
+    "name": "Cream Curiosity",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cream_fingers",
+    "name": "Cream Fingers",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cream_of_vegetable_soup",
+    "name": "Cream of Vegetable Soup",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "creamed_organ_soup",
+    "name": "Creamed Organ Soup",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "creamy_clouds_of_nectar",
+    "name": "Creamy Clouds Of Nectar",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "creamy_sauce",
+    "name": "Creamy Sauce",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "creamy_treat",
+    "name": "Creamy Treat",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "creature_egg",
+    "name": "Creature Egg",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "creature_pellets",
+    "name": "Creature Pellets",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crew_berth",
+    "name": "Crew Berth",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crew_footlocker",
+    "name": "Crew Footlocker",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crew_locker",
+    "name": "Crew Locker",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crew_manifest",
+    "name": "Crew Manifest",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crimson_freighter_trail",
+    "name": "Crimson Freighter Trail",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "crolium",
+    "name": "Crolium",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crunchy_caramel",
+    "name": "Crunchy Caramel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crunchy_wings",
+    "name": "Crunchy Wings",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cryo_pump",
+    "name": "Cryo-Pump",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cryogenic_chamber",
+    "name": "Cryogenic Chamber",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crystal_flesh",
+    "name": "Crystal Flesh",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crystal_fragment",
+    "name": "Crystal Fragment",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crystal_jelly",
+    "name": "Crystal Jelly",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crystal_sulphide",
+    "name": "Crystal Sulphide",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crystalline_soup",
+    "name": "Crystalline Soup",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crystallised_heart",
+    "name": "Crystallised Heart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "crystallised_helium",
+    "name": "Crystallised Helium",
+    "group": "resource",
+    "value": 82
+  },
+  {
+    "id": "cube",
+    "name": "Cube",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cuboid_inner_door",
+    "name": "Cuboid Inner Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cuboid_inner_wall",
+    "name": "Cuboid Inner Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cuboid_roof_cap",
+    "name": "Cuboid Roof Cap",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cuboid_room",
+    "name": "Cuboid Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cuboid_room_flooring",
+    "name": "Cuboid Room Flooring",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cuboid_room_foundation_strut",
+    "name": "Cuboid Room Foundation Strut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cuboid_room_foundation_strut_quad",
+    "name": "Cuboid Room Foundation Strut Quad",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cuboid_room_frame",
+    "name": "Cuboid Room Frame",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cultivation_chamber",
+    "name": "Cultivation Chamber",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "curdy_cracker",
+    "name": "Curdy Cracker",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "curious_corn",
+    "name": "Curious Corn",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "curious_fauna_decal",
+    "name": "Curious Fauna Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "curly_coral",
+    "name": "Curly Coral",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cursed_dust",
+    "name": "Cursed Dust",
+    "group": "resource",
+    "value": 959
+  },
+  {
+    "id": "curved_corridor",
+    "name": "Curved Corridor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "curved_cuboid_roof",
+    "name": "Curved Cuboid Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "curved_cuboid_wall",
+    "name": "Curved Cuboid Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "curved_desk",
+    "name": "Curved Desk",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "curved_freighter_corridor",
+    "name": "Curved Freighter Corridor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "curved_pipe",
+    "name": "Curved Pipe",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "custard_curiosity",
+    "name": "Custard Curiosity",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "custard_doughnut",
+    "name": "Custard Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "custard_fancy",
+    "name": "Custard Fancy",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "custard_tart",
+    "name": "Custard Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cyclonic_eel",
+    "name": "Cyclonic Eel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cyclonic_lathe",
+    "name": "Cyclonic Lathe",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cyclopic_eel",
+    "name": "Cyclopic Eel",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "cyclotron_ballista",
+    "name": "Cyclotron Ballista",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cyclotron_ballista_coolant_sigma",
+    "name": "Cyclotron Ballista Coolant Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cyclotron_ballista_coolant_tau",
+    "name": "Cyclotron Ballista Coolant Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cyclotron_ballista_coolant_theta",
+    "name": "Cyclotron Ballista Coolant Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cyclotron_ballista_damage_sigma",
+    "name": "Cyclotron Ballista Damage Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cyclotron_ballista_damage_tau",
+    "name": "Cyclotron Ballista Damage Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cyclotron_ballista_damage_theta",
+    "name": "Cyclotron Ballista Damage Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cyclotron_ballista_fire_rate_sigma",
+    "name": "Cyclotron Ballista Fire Rate Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cyclotron_ballista_fire_rate_tau",
+    "name": "Cyclotron Ballista Fire Rate Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cyclotron_ballista_fire_rate_theta",
+    "name": "Cyclotron Ballista Fire Rate Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cyclotron_ballista_upgrade",
+    "name": "Cyclotron Ballista Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "cylinder",
+    "name": "Cylinder",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cylindrical_room",
+    "name": "Cylindrical Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cylindrical_room_frame",
+    "name": "Cylindrical Room Frame",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "cymatygen",
+    "name": "Cymatygen",
+    "group": "resource",
+    "value": 275
+  },
+  {
+    "id": "cyto_phosphate",
+    "name": "Cyto-Phosphate",
+    "group": "resource",
+    "value": 201
+  },
+  {
+    "id": "daedalus_engine",
+    "name": "Daedalus Engine",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "daedalus_engine_upgrade",
+    "name": "Daedalus Engine Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "damage_radius",
+    "name": "Damage Radius",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "damage_radius_tau",
+    "name": "Damage Radius Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "damaged_electrode",
+    "name": "Damaged Electrode",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "damaged_gears",
+    "name": "Damaged Gears",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "damaged_wiring",
+    "name": "Damaged Wiring",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "dangling_orb",
+    "name": "Dangling Orb",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dark_matter",
+    "name": "Dark Matter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dawns_end",
+    "name": "Dawn's End",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dayzhenyov_kosh_v2_1",
+    "name": "Dayzhenyov-kosh v2.1",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "de_scented_bottles",
+    "name": "De-Scented Bottles",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "deathly_cold_ice_cream",
+    "name": "Deathly-Cold Ice Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "decal_hellogames",
+    "name": "Decal (HelloGames)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "decals",
+    "name": "Decals",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "decommissioned_circuits",
+    "name": "Decommissioned Circuits",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "decrypted_user_data",
+    "name": "Decrypted User Data",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "deepwater_angler",
+    "name": "Deepwater Angler",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "deepwater_chamber",
+    "name": "Deepwater Chamber",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "defence_chit",
+    "name": "Defence Chit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "defence_systems_upgrade",
+    "name": "Defence Systems Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "defiant_recoil_ii",
+    "name": "Defiant Recoil II",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "deflection_enhancement_sigma",
+    "name": "Deflection Enhancement Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "deflection_enhancement_tau",
+    "name": "Deflection Enhancement Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "deflection_enhancement_theta",
+    "name": "Deflection Enhancement Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "deflector_shield",
+    "name": "Deflector Shield",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "deflector_shield_atlas",
+    "name": "Deflector Shield (Atlas)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "deflector_shield_corvette",
+    "name": "Deflector Shield (Corvette)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "deflector_shield_upgrade",
+    "name": "Deflector Shield Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "delicate_flora_farm",
+    "name": "Delicate Flora (FARM)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "delicate_flora_plnt",
+    "name": "Delicate Flora (PLNT)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "delicate_meringue",
+    "name": "Delicate Meringue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "delicious_vegetable_stew",
+    "name": "Delicious Vegetable Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "desk_chair",
+    "name": "Desk Chair",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "destablised_sodium",
+    "name": "Destablised Sodium",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "detoxified_slime",
+    "name": "Detoxified Slime",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "detritum",
+    "name": "Detritum",
+    "group": "resource",
+    "value": 27.5
+  },
+  {
+    "id": "deuterium",
+    "name": "Deuterium",
+    "group": "resource",
+    "value": 34
+  },
+  {
+    "id": "devilled_organs",
+    "name": "Devilled Organs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "di_hydrogen",
+    "name": "Di-hydrogen",
+    "group": "resource",
+    "value": 34
+  },
+  {
+    "id": "di_hydrogen_jelly",
+    "name": "Di-hydrogen Jelly",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dimensional_matrix",
+    "name": "Dimensional Matrix",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dioxite",
+    "name": "Dioxite",
+    "group": "resource",
+    "value": 62
+  },
+  {
+    "id": "diplo_chunks",
+    "name": "Diplo Chunks",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dirt",
+    "name": "Dirt",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dirty_bronze",
+    "name": "Dirty Bronze",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dirty_meat",
+    "name": "Dirty Meat",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dish_receptor_antenna",
+    "name": "Dish Receptor Antenna",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "divergence_cube",
+    "name": "Divergence Cube",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "domed_casing",
+    "name": "Domed Casing",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "doomed_cream_cake",
+    "name": "Doomed Cream Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "door",
+    "name": "Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "double_cultivation_chamber",
+    "name": "Double Cultivation Chamber",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dough",
+    "name": "Dough",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dragonfish",
+    "name": "Dragonfish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "draped_sail_timber_roof",
+    "name": "Draped Sail Timber Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "drawers",
+    "name": "Drawers",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "drawn_cart",
+    "name": "Drawn Cart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dream_aerial",
+    "name": "Dream Aerial",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dredging_laser",
+    "name": "Dredging Laser",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "drift_suspension",
+    "name": "Drift Suspension",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "drone_alert_poster",
+    "name": "Drone Alert Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dual_chrome_firework",
+    "name": "Dual Chrome Firework",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dual_pronged_antenna",
+    "name": "Dual-Pronged Antenna",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ducting_joint",
+    "name": "Ducting Joint",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ducting_outlet",
+    "name": "Ducting Outlet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dustadtte_mark_ii",
+    "name": "Dustadtte Mark II",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "dwarf_palm",
+    "name": "Dwarf Palm",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dynamic_resonator",
+    "name": "Dynamic Resonator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "dyson_pump",
+    "name": "Dyson Pump",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "earthy_pie",
+    "name": "Earthy Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "echinocactus",
+    "name": "Echinocactus",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "echo_locator",
+    "name": "Echo Locator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "echo_seed",
+    "name": "Echo Seed",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "economy_scanner",
+    "name": "Economy Scanner",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "edible_chum",
+    "name": "Edible Chum",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "efficient_thrusters",
+    "name": "Efficient Thrusters",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "efficient_water_jets",
+    "name": "Efficient Water Jets",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "elaborate_alloy_roof",
+    "name": "Elaborate Alloy Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "electric_cube",
+    "name": "Electric Cube",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "electric_eel",
+    "name": "Electric Eel",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "electrical_cloaking_unit",
+    "name": "Electrical Cloaking Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "electrical_wiring",
+    "name": "Electrical Wiring",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "electromagnetic_generator",
+    "name": "Electromagnetic Generator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "electron_vapour",
+    "name": "Electron Vapour",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "emergency_heater",
+    "name": "Emergency Heater",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "emergency_light",
+    "name": "Emergency Light",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "emergency_signal_scanner",
+    "name": "Emergency Signal Scanner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "emergency_warp_unit",
+    "name": "Emergency Warp Unit",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "emeril",
+    "name": "Emeril",
+    "group": "resource",
+    "value": 114
+  },
+  {
+    "id": "emeril_drive",
+    "name": "Emeril Drive",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "emeril_starship_trail",
+    "name": "Emeril Starship Trail",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "emeril_sunstar",
+    "name": "Emeril Sunstar",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "encrusted_worm",
+    "name": "Encrusted Worm",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "engine_cover",
+    "name": "Engine Cover",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "englobed_shade",
+    "name": "Englobed Shade",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "enormous_metal_cog",
+    "name": "Enormous Metal Cog",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "enriched_biscuit",
+    "name": "Enriched Biscuit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "enriched_carbon",
+    "name": "Enriched Carbon",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "entwining_tree",
+    "name": "Entwining Tree",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "environment_control_unit",
+    "name": "Environment Control Unit",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "enzyme_fluid",
+    "name": "Enzyme Fluid",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "erased_clam",
+    "name": "Erased Clam",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "esophageal_surprise",
+    "name": "Esophageal Surprise",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ever_boiling_cake",
+    "name": "Ever-Boiling Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ever_burning_jam",
+    "name": "Ever-burning Jam",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "evergreen_tree",
+    "name": "Evergreen Tree",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "excavated_bones",
+    "name": "Excavated Bones",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "excavation_claw",
+    "name": "Excavation Claw",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "exceptional_intuition_vii",
+    "name": "Exceptional Intuition VII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "exo_skiff",
+    "name": "Exo-Skiff",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "exocraft_boosters",
+    "name": "Exocraft Boosters",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "exocraft_boosters_upgrade",
+    "name": "Exocraft Boosters Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "exocraft_boosters_upgrade_sigma",
+    "name": "Exocraft Boosters Upgrade Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "exocraft_boosters_upgrade_tau",
+    "name": "Exocraft Boosters Upgrade Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "exocraft_mining_laser",
+    "name": "Exocraft Mining Laser",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "exocraft_mining_laser_upgrade",
+    "name": "Exocraft Mining Laser Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "exocraft_radar",
+    "name": "Exocraft Radar",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "exocraft_specialists_room",
+    "name": "Exocraft Specialist's Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "exocraft_summoning_station",
+    "name": "Exocraft Summoning Station",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "exocraft_summoning_unit",
+    "name": "Exocraft Summoning Unit",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "exocraft_terminal",
+    "name": "Exocraft Terminal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "exosuit_expansion_unit",
+    "name": "Exosuit Expansion Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "exosuit_upgrade_chart",
+    "name": "Exosuit Upgrade Chart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "expanding_cube_gadget",
+    "name": "Expanding Cube Gadget",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "experiment_13j_v",
+    "name": "Experiment 13J/V",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "experiment_37c_97o",
+    "name": "Experiment 37C/97O",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "experiment_5_zv2",
+    "name": "Experiment 5-ZV2",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "experiment_6_5",
+    "name": "Experiment 6/5",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "experiment_b_3",
+    "name": "Experiment B/3",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "experiment_b_9",
+    "name": "Experiment B/9",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "experiment_j_a21",
+    "name": "Experiment J/A21",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "experiment_js9_7",
+    "name": "Experiment JS9-7",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "experiment_k_7",
+    "name": "Experiment K/7",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "experiment_ra1_kg8",
+    "name": "Experiment RA1 KG8",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "experiment_t32_j",
+    "name": "Experiment T32-J",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "experiment_y_f15",
+    "name": "Experiment Y-F15",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "experimental_power_fluid",
+    "name": "Experimental Power Fluid",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "expired_braincoral",
+    "name": "Expired Braincoral",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "exploded_panel",
+    "name": "Exploded Panel",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "explosive",
+    "name": "Explosive",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "explosive_drones",
+    "name": "Explosive Drones",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "exterior_catwalk",
+    "name": "Exterior Catwalk",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "exterior_platform",
+    "name": "Exterior Platform",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extra_fluffy_batter",
+    "name": "Extra-Fluffy Batter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extra_fluffy_cream_cake",
+    "name": "Extra-Fluffy Cream Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_alloy_door",
+    "name": "Extruded Alloy Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_alloy_horizontal_window",
+    "name": "Extruded Alloy Horizontal Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_alloy_small_window",
+    "name": "Extruded Alloy Small Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_alloy_wall",
+    "name": "Extruded Alloy Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_alloy_wall_cap",
+    "name": "Extruded Alloy Wall Cap",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_alloy_window",
+    "name": "Extruded Alloy Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_panelled_stone_wall",
+    "name": "Extruded Panelled Stone Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_stone_door",
+    "name": "Extruded Stone Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_stone_large_window",
+    "name": "Extruded Stone Large Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_stone_small_window",
+    "name": "Extruded Stone Small Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_stone_wall",
+    "name": "Extruded Stone Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_stone_wall_cap",
+    "name": "Extruded Stone Wall Cap",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_timber_large_window",
+    "name": "Extruded Timber Large Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_timber_small_window",
+    "name": "Extruded Timber Small Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_timber_wall",
+    "name": "Extruded Timber Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_timber_wall_a",
+    "name": "Extruded Timber Wall A",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_timber_wall_b",
+    "name": "Extruded Timber Wall B",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_timber_wall_cap",
+    "name": "Extruded Timber Wall Cap",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "extruded_timber_glass_door",
+    "name": "Extruded Timber-Glass Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "factory_override_unit",
+    "name": "Factory Override Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fadilims_mark_xv",
+    "name": "Fadilims Mark XV",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fading_plaarkto_ipio",
+    "name": "Fading Plaarkto-Ipio",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fading_rucadrumm",
+    "name": "Fading Rucadrumm",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "faecium",
+    "name": "Faecium",
+    "group": "resource",
+    "value": 30
+  },
+  {
+    "id": "falling_shapes_poster",
+    "name": "Falling Shapes Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fascination_bead",
+    "name": "Fascination Bead",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "faulty_hologram",
+    "name": "Faulty Hologram",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fauna_analyzer_sigma",
+    "name": "Fauna Analyzer Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fauna_analyzer_tau",
+    "name": "Fauna Analyzer Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fauna_analyzer_theta",
+    "name": "Fauna Analyzer Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "feline_liver",
+    "name": "Feline Liver",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fermented_fruit",
+    "name": "Fermented Fruit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ferrite_bowfin",
+    "name": "Ferrite Bowfin",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "ferrite_dust",
+    "name": "Ferrite Dust",
+    "group": "resource",
+    "value": 14
+  },
+  {
+    "id": "fetirlitsre_mark_xix",
+    "name": "Fetirlitsre Mark XIX",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fibrous_stew",
+    "name": "Fibrous Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fields_dartfish",
+    "name": "Field's Dartfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "fiendish_roe",
+    "name": "Fiendish Roe",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fiery_vegetable_stew",
+    "name": "Fiery Vegetable Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "final_riposte_i",
+    "name": "Final Riposte I",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fire_water",
+    "name": "Fire Water",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fireberry",
+    "name": "Fireberry",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "firebox_fairing",
+    "name": "Firebox Fairing",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "firefox_cowling",
+    "name": "Firefox Cowling",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "first_spawn_relics",
+    "name": "First Spawn Relics",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fish_biscuit",
+    "name": "Fish Biscuit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fish_fry",
+    "name": "Fish Fry",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fish_pie",
+    "name": "Fish Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fishing_rig",
+    "name": "Fishing Rig",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fishy_slab",
+    "name": "Fishy Slab",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "flag_1",
+    "name": "Flag 1",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flag_2",
+    "name": "Flag 2",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flag_3",
+    "name": "Flag 3",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flag_4",
+    "name": "Flag 4",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flarecap_toadstool",
+    "name": "Flarecap Toadstool",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flashfire_eel",
+    "name": "Flashfire Eel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flat_alloy_roof",
+    "name": "Flat Alloy Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flat_panel",
+    "name": "Flat Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flat_stone_roof",
+    "name": "Flat Stone Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flat_timber_roof",
+    "name": "Flat Timber Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flavoursome_organs",
+    "name": "Flavoursome Organs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flavoursome_sauce",
+    "name": "Flavoursome Sauce",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fleet_command_room",
+    "name": "Fleet Command Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fleeting_daanseon_uzan",
+    "name": "Fleeting Daanseon-Uzan",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fleeting_enetinoser_dede",
+    "name": "Fleeting Enetinoser-Dede",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fleeting_johrididja_ains",
+    "name": "Fleeting Johrididja-Ains",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "flesh_rope",
+    "name": "Flesh Rope",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fleshy_cylinder",
+    "name": "Fleshy Cylinder",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flight_assist_override",
+    "name": "Flight Assist Override",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "flight_path_poster",
+    "name": "Flight Path Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "floor_mat",
+    "name": "Floor Mat",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "floor_switch",
+    "name": "Floor Switch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flora_analyzer_sigma",
+    "name": "Flora Analyzer Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "flora_analyzer_tau",
+    "name": "Flora Analyzer Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "flora_analyzer_theta",
+    "name": "Flora Analyzer Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "flora_containment_1",
+    "name": "Flora Containment 1",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flora_containment_2",
+    "name": "Flora Containment 2",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flora_containment_3",
+    "name": "Flora Containment 3",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "floral_canister",
+    "name": "Floral Canister",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "floral_wafer",
+    "name": "Floral Wafer",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "flourishing_shalefish",
+    "name": "Flourishing Shalefish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "fluffy_caramel_delight",
+    "name": "Fluffy Caramel Delight",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fluffy_throatripper",
+    "name": "Fluffy Throatripper",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "folded_sail_alloy_roof",
+    "name": "Folded Sail Alloy Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "folded_sail_timber_roof",
+    "name": "Folded Sail Timber Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fools_goldfish",
+    "name": "Fool's Goldfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "foraged_mushrooms",
+    "name": "Foraged Mushrooms",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "forbidden_exosuit_module",
+    "name": "Forbidden Exosuit Module",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "forbidden_multi_tool_module",
+    "name": "Forbidden Multi-Tool Module",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "forged_passport",
+    "name": "Forged Passport",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fossil_display",
+    "name": "Fossil Display",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fossil_sample",
+    "name": "Fossil Sample",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fossilised_biped_legs",
+    "name": "Fossilised Biped Legs",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "foundation_base_building",
+    "name": "Foundation (Base building)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fourier_de_limiter",
+    "name": "Fourier De-Limiter",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fragile_heart",
+    "name": "Fragile Heart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fragile_icthyoscale",
+    "name": "Fragile Icthyoscale",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "fragile_neural_stem",
+    "name": "Fragile Neural Stem",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fragile_shell",
+    "name": "Fragile Shell",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fragment_supercharger",
+    "name": "Fragment Supercharger",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fragmented_qualia",
+    "name": "Fragmented Qualia",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frameshift_catapult",
+    "name": "Frameshift Catapult",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "freighter_corridor",
+    "name": "Freighter Corridor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "freighter_corridor_endurance",
+    "name": "Freighter Corridor (Endurance)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "freighter_cross_junction",
+    "name": "Freighter Cross Junction",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "freighter_external_stairs",
+    "name": "Freighter External Stairs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "freighter_glass_corridor",
+    "name": "Freighter Glass Corridor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "freighter_glass_stairs",
+    "name": "Freighter Glass Stairs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "freighter_hyperdrive",
+    "name": "Freighter Hyperdrive",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "freighter_junction",
+    "name": "Freighter Junction",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "freighter_stairs",
+    "name": "Freighter Stairs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "freighter_stairs_endurance",
+    "name": "Freighter Stairs (Endurance)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "freighter_storage_unit",
+    "name": "Freighter Storage Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "freighter_warp_reactor_sigma",
+    "name": "Freighter Warp Reactor Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "freighter_warp_reactor_tau",
+    "name": "Freighter Warp Reactor Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "freighter_warp_reactor_theta",
+    "name": "Freighter Warp Reactor Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fresh_milk",
+    "name": "Fresh Milk",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frigate_fuel_100_tonnes",
+    "name": "Frigate Fuel (100 Tonnes)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frigate_fuel_200_tonnes",
+    "name": "Frigate Fuel (200 Tonnes)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frigate_fuel_50_tonnes",
+    "name": "Frigate Fuel (50 Tonnes)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frost_crystal",
+    "name": "Frost Crystal",
+    "group": "resource",
+    "value": 12
+  },
+  {
+    "id": "frostbite_ray",
+    "name": "Frostbite Ray",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frosted_mire",
+    "name": "Frosted Mire",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frostscale_trout",
+    "name": "Frostscale Trout",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frostshell_clam",
+    "name": "Frostshell Clam",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frostwort",
+    "name": "Frostwort",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frozen_isopod",
+    "name": "Frozen Isopod",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frozen_knifejaw",
+    "name": "Frozen Knifejaw",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frozen_planter",
+    "name": "Frozen Planter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frozen_tubers",
+    "name": "Frozen Tubers",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "frozen_whelk",
+    "name": "Frozen Whelk",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fruit_tree",
+    "name": "Fruit Tree",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fruity_ice_cream",
+    "name": "Fruity Ice Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fruity_pudding",
+    "name": "Fruity Pudding",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fuel_cell",
+    "name": "Fuel Cell",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fuel_inverter",
+    "name": "Fuel Inverter",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fuel_oxidiser",
+    "name": "Fuel Oxidiser",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fuel_pod_cover",
+    "name": "Fuel Pod Cover",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fuel_pump",
+    "name": "Fuel Pump",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fuel_rods",
+    "name": "Fuel Rods",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fumarole_gulper",
+    "name": "Fumarole Gulper",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "fungal_cluster",
+    "name": "Fungal Cluster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fungal_mould",
+    "name": "Fungal Mould",
+    "group": "resource",
+    "value": 16
+  },
+  {
+    "id": "fungal_omelette",
+    "name": "Fungal Omelette",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fungal_tart",
+    "name": "Fungal Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "furball_jelly",
+    "name": "Furball Jelly",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "furnace_tank",
+    "name": "Furnace Tank",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fusion_accelerant",
+    "name": "Fusion Accelerant",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fusion_core",
+    "name": "Fusion Core",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "fusion_engine",
+    "name": "Fusion Engine",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fusion_engine_upgrade",
+    "name": "Fusion Engine Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "fusion_ignitor",
+    "name": "Fusion Ignitor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "g38_jp6_elevated_loop",
+    "name": "G38-JP6 Elevated Loop",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "galactic_hub_decal",
+    "name": "Galactic Hub Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "galactic_trade_room",
+    "name": "Galactic Trade Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "galactic_trade_terminal",
+    "name": "Galactic Trade Terminal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gamma_root",
+    "name": "Gamma Root",
+    "group": "resource",
+    "value": 16
+  },
+  {
+    "id": "gamma_squid",
+    "name": "Gamma Squid",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gamma_weed",
+    "name": "Gamma Weed",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gas_canister",
+    "name": "Gas Canister",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gas_extractor",
+    "name": "Gas Extractor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gas_worm",
+    "name": "Gas-Worm",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gek_charm",
+    "name": "Gek Charm",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gek_decal",
+    "name": "Gek Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gek_hypnosis_poster",
+    "name": "Gek Hypnosis Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gek_relic",
+    "name": "Gek Relic",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "geknip",
+    "name": "GekNip",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gelatinous_goop",
+    "name": "Gelatinous Goop",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gelatinous_membrane",
+    "name": "Gelatinous Membrane",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gelatinous_sponge",
+    "name": "Gelatinous Sponge",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gem_encrusted_rock",
+    "name": "Gem-Encrusted Rock",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "generator_coupling",
+    "name": "Generator Coupling",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "geno_prawn",
+    "name": "Geno-Prawn",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "geobay",
+    "name": "Geobay",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "geode_cave",
+    "name": "Geode (cave)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "geode_land",
+    "name": "Geode (land)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "geodesite",
+    "name": "Geodesite",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "geology_cannon",
+    "name": "Geology Cannon",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "geology_cannon_upgrade",
+    "name": "Geology Cannon Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "giant_egg",
+    "name": "Giant Egg",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "giant_hairy_crab",
+    "name": "Giant Hairy Crab",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "giant_ray",
+    "name": "Giant Ray",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "giant_whiskerfish",
+    "name": "Giant Whiskerfish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "giant_witchfin",
+    "name": "Giant Witchfin",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "gift_of_auhetena",
+    "name": "Gift of Auhetena",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "gift_of_jarjeluse_ebro",
+    "name": "Gift of Jarjeluse-Ebro",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "girder_array",
+    "name": "Girder Array",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "glacier_carp",
+    "name": "Glacier Carp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "glacier_fish",
+    "name": "Glacier Fish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "glass",
+    "name": "Glass",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "glass_angel",
+    "name": "Glass Angel",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "glass_cuboid_room",
+    "name": "Glass Cuboid Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "glass_grains",
+    "name": "Glass Grains",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "glass_roofed_corridor",
+    "name": "Glass Roofed Corridor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "glass_tunnel",
+    "name": "Glass Tunnel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "glitching_separator",
+    "name": "Glitching Separator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "glittering_honey_cake",
+    "name": "Glittering Honey Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "globe_tree",
+    "name": "Globe Tree",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "glowing_catfish",
+    "name": "Glowing Catfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "glowing_mineral",
+    "name": "Glowing Mineral",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "glowing_pie",
+    "name": "Glowing Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gluey_nodule",
+    "name": "Gluey Nodule",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "glyph_1_16",
+    "name": "Glyph 1 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_10_16",
+    "name": "Glyph 10 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_11_16",
+    "name": "Glyph 11 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_12_16",
+    "name": "Glyph 12 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_13_16",
+    "name": "Glyph 13 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_14_16",
+    "name": "Glyph 14 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_15_16",
+    "name": "Glyph 15 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_16_16",
+    "name": "Glyph 16 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_2_16",
+    "name": "Glyph 2 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_3_16",
+    "name": "Glyph 3 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_4_16",
+    "name": "Glyph 4 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_5_16",
+    "name": "Glyph 5 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_6_16",
+    "name": "Glyph 6 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_7_16",
+    "name": "Glyph 7 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_8_16",
+    "name": "Glyph 8 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "glyph_9_16",
+    "name": "Glyph 9 / 16",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "gold",
+    "name": "Gold",
+    "group": "resource",
+    "value": 353
+  },
+  {
+    "id": "gold_astronaut_statue",
+    "name": "Gold Astronaut Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gold_atlas_statue",
+    "name": "Gold Atlas Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gold_blob_statue",
+    "name": "Gold Blob Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gold_diplo_statue",
+    "name": "Gold Diplo Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gold_fighter_statue",
+    "name": "Gold Fighter Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gold_gek_statue",
+    "name": "Gold Gek Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gold_nugget",
+    "name": "Gold Nugget",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gold_walker_statue",
+    "name": "Gold Walker Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "golden_counter",
+    "name": "Golden Counter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "golden_counter_corner",
+    "name": "Golden Counter Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "golden_gek_poster",
+    "name": "Golden Gek Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "golden_half_counter",
+    "name": "Golden Half Counter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "golden_jellyfish",
+    "name": "Golden Jellyfish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "golden_starship_trail",
+    "name": "Golden Starship Trail",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "golden_table",
+    "name": "Golden Table",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gooey_butter",
+    "name": "Gooey Butter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gooey_caramel_cake",
+    "name": "Gooey Caramel Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gooey_chocolate_cake",
+    "name": "Gooey Chocolate Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gooey_custard_fancy",
+    "name": "Gooey Custard Fancy",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gooey_fruit_surprise",
+    "name": "Gooey Fruit Surprise",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gooey_honey_puff",
+    "name": "Gooey Honey Puff",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gooey_mouthburner",
+    "name": "Gooey Mouthburner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gooey_protobutter",
+    "name": "Gooey ProtoButter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gooey_protodoughnut",
+    "name": "Gooey ProtoDoughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gooey_screamer",
+    "name": "Gooey Screamer",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "grafted_eyes",
+    "name": "Grafted Eyes",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "grahberry",
+    "name": "Grahberry",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "grahgrah",
+    "name": "GrahGrah",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "grahjam",
+    "name": "Grahj'am",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "grantine",
+    "name": "Grantine",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gravitino_ball",
+    "name": "Gravitino Ball",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gravitino_host",
+    "name": "Gravitino Host",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gravity_of_enoharaz",
+    "name": "Gravity of Enoharaz",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "green_design_decal",
+    "name": "Green Design Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "green_firework",
+    "name": "Green Firework",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "green_wall_screen",
+    "name": "Green Wall Screen",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "green_ring_octopus",
+    "name": "Green-Ring Octopus",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "greenscale_bloater",
+    "name": "Greenscale Bloater",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "grenade_intensity_sigma",
+    "name": "Grenade Intensity Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "grenade_intensity_tau",
+    "name": "Grenade Intensity Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "grenade_intensity_theta",
+    "name": "Grenade Intensity Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "grenade_propulsion",
+    "name": "Grenade Propulsion",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "grenade_propulsion_tau",
+    "name": "Grenade Propulsion Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "grilled_fillet",
+    "name": "Grilled Fillet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "grilled_tentacle",
+    "name": "Grilled Tentacle",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "grilled_tentacles",
+    "name": "Grilled Tentacles",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "grip_boost_suspension",
+    "name": "Grip Boost Suspension",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "gristle_pie",
+    "name": "Gristle Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gritty_meat_pie",
+    "name": "Gritty Meat Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ground_meat",
+    "name": "Ground Meat",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "growing_singularity",
+    "name": "Growing Singularity",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "gutrot_flower",
+    "name": "Gutrot Flower",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "h_beam_stack",
+    "name": "H-Beam Stack",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hadal_core",
+    "name": "Hadal Core",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hand_of_approval_decal",
+    "name": "Hand of Approval Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "handful_of_cogs",
+    "name": "Handful of Cogs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hanging_flag_1",
+    "name": "Hanging Flag 1",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hanging_flag_2",
+    "name": "Hanging Flag 2",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hanging_lamp",
+    "name": "Hanging Lamp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hardened_shell",
+    "name": "Hardened Shell",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hardframe_body",
+    "name": "Hardframe Body",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hardframe_cowling",
+    "name": "Hardframe Cowling",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hardframe_diffuser",
+    "name": "Hardframe Diffuser",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hardframe_engine",
+    "name": "Hardframe Engine",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hardframe_left_arm",
+    "name": "Hardframe Left Arm",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hardframe_legs",
+    "name": "Hardframe Legs",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hardframe_right_arm",
+    "name": "Hardframe Right Arm",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hardy_shrub",
+    "name": "Hardy Shrub",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "harmonic_brain",
+    "name": "Harmonic Brain",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "harmony_of_gudhiekt_mydo",
+    "name": "Harmony of Gudhiekt-Mydo",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "haunted_chocolate_dreams",
+    "name": "Haunted Chocolate Dreams",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "haunted_fillet",
+    "name": "Haunted Fillet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "haunted_pie",
+    "name": "Haunted Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "haunted_wafer",
+    "name": "Haunted Wafer",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "haz_mat_gauntlet",
+    "name": "Haz-Mat Gauntlet",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hazard_decal",
+    "name": "Hazard Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hazard_protection",
+    "name": "Hazard Protection",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hazard_protection_unit_base_building",
+    "name": "Hazard Protection Unit (base building)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "health_module_sigma",
+    "name": "Health Module Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "health_module_tau",
+    "name": "Health Module Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "health_module_theta",
+    "name": "Health Module Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "health_station",
+    "name": "Health Station",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "healthy_wheatblock",
+    "name": "Healthy Wheatblock",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "heart_of_the_sun",
+    "name": "Heart of the Sun",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "heat_capacitor",
+    "name": "Heat Capacitor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "heavy_linkage",
+    "name": "Heavy Linkage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "heavy_scaffold",
+    "name": "Heavy Scaffold",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "heavy_duty_furniture",
+    "name": "Heavy-Duty Furniture",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "helix_sawfish",
+    "name": "Helix Sawfish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "heptaploid_wheat",
+    "name": "Heptaploid Wheat",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "herb_encrusted_flesh",
+    "name": "Herb-Encrusted Flesh",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "herbal_crunchie",
+    "name": "Herbal Crunchie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "heridium",
+    "name": "Heridium",
+    "group": "resource",
+    "value": 27.5
+  },
+  {
+    "id": "hermetic_seal",
+    "name": "Hermetic Seal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "herox",
+    "name": "Herox",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hetyembran_fabar_mark_vii",
+    "name": "Hetyembran-Fabar Mark VII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hex_core",
+    "name": "Hex Core",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hexaberry",
+    "name": "Hexaberry",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hexagonal_table",
+    "name": "Hexagonal Table",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hexite",
+    "name": "Hexite",
+    "group": "resource",
+    "value": 654
+  },
+  {
+    "id": "hexplate_bush",
+    "name": "Hexplate Bush",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hexscale_minnow",
+    "name": "Hexscale Minnow",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "hi_slide_suspension",
+    "name": "Hi-Slide Suspension",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hidden_nutverdis_upug",
+    "name": "Hidden Nutverdis-Upug",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "high_energy_ducting",
+    "name": "High-Energy Ducting",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "high_energy_shield",
+    "name": "High-Energy Shield",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "high_fibre_pie",
+    "name": "High-Fibre Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "high_gravity_freighter_trail",
+    "name": "High-Gravity Freighter Trail",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "high_power_sonar",
+    "name": "High-Power Sonar",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "historical_document",
+    "name": "Historical Document",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "historiographical_dosimeter",
+    "name": "Historiographical Dosimeter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "holo_door",
+    "name": "Holo-Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "holographic_analyser",
+    "name": "Holographic Analyser",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "holographic_chart_projector",
+    "name": "Holographic Chart Projector",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "holographic_crankshaft",
+    "name": "Holographic Crankshaft",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "holographic_globe_gadget",
+    "name": "Holographic Globe Gadget",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "homeworld_repeater",
+    "name": "Homeworld Repeater",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "homing_grenade",
+    "name": "Homing Grenade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "homingbolt_adaptor",
+    "name": "Homingbolt Adaptor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "honey_butter",
+    "name": "Honey Butter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "honey_doughnut",
+    "name": "Honey Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "honey_ice_cream",
+    "name": "Honey Ice Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "honey_tart",
+    "name": "Honey Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "honey_waffle",
+    "name": "Honey Waffle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "honey_soaked_fancy",
+    "name": "Honey-Soaked Fancy",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "honeybutter_doughnut",
+    "name": "Honeybutter Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "honied_angel_cake",
+    "name": "Honied Angel Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "honied_proto_butter",
+    "name": "Honied Proto-Butter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "honied_proto_cake",
+    "name": "Honied Proto-Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "honied_throat_sticker",
+    "name": "Honied Throat-Sticker",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "horizontal_alloy_window",
+    "name": "Horizontal Alloy Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "horizontal_timber_window",
+    "name": "Horizontal Timber Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "horrific_decal",
+    "name": "Horrific Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "horrific_flesh_helmet",
+    "name": "Horrific Flesh-Helmet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "horrifying_mush",
+    "name": "Horrifying Mush",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "horrifying_gooey_delight",
+    "name": "Horrifying, Gooey Delight",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hot_ice",
+    "name": "Hot Ice",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hull_fracture",
+    "name": "Hull Fracture",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hull_linkage",
+    "name": "Hull Linkage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "humboldt_drive",
+    "name": "Humboldt Drive",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "humboldt_drive_upgrade",
+    "name": "Humboldt Drive Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "humming_sac",
+    "name": "Humming Sac",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hunter_of_netsukaido_cutyl",
+    "name": "Hunter of Netsukaido Cutyl",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hyaline_brain",
+    "name": "Hyaline Brain",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hybrid_cake",
+    "name": "Hybrid Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hydraulic_wiring",
+    "name": "Hydraulic Wiring",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hydraulics_damage",
+    "name": "Hydraulics Damage",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hydroponic_tray",
+    "name": "Hydroponic Tray",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hydrothermal_fuel_cell",
+    "name": "Hydrothermal Fuel Cell",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hyglese",
+    "name": "Hyglese",
+    "group": "resource",
+    "value": 0
+  },
+  {
+    "id": "hyper_cockle",
+    "name": "Hyper-Cockle",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "hyperdrive",
+    "name": "Hyperdrive",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hyperdrive_atlas",
+    "name": "Hyperdrive (Atlas)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hyperdrive_upgrade",
+    "name": "Hyperdrive Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "hypnotic_eye",
+    "name": "Hypnotic Eye",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "hypnotic_octopus",
+    "name": "Hypnotic Octopus",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "icarus_fuel_system",
+    "name": "Icarus Fuel System",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "ice_cream",
+    "name": "Ice Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ice_darter",
+    "name": "Ice Darter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iceblood_gulper",
+    "name": "Iceblood Gulper",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "iced_screams",
+    "name": "Iced Screams",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "icey_marrow",
+    "name": "Icey Marrow",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "igneous_crystal",
+    "name": "Igneous Crystal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "igneous_drop",
+    "name": "Igneous Drop",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "illegal_hazard_protection_upgrade",
+    "name": "Illegal Hazard Protection Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "illuminated_sign",
+    "name": "Illuminated Sign",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "immortal_flatfish",
+    "name": "Immortal Flatfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "impact_damage_omega",
+    "name": "Impact Damage Omega",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "impact_damage_sigma",
+    "name": "Impact Damage Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "impact_damage_tau",
+    "name": "Impact Damage Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "impact_damage_theta",
+    "name": "Impact Damage Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "impact_igniter",
+    "name": "Impact Igniter",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "impossible_membrane",
+    "name": "Impossible Membrane",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "impulse_beans",
+    "name": "Impulse Beans",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "impulse_of_iogamagao_eutr",
+    "name": "Impulse of Iogamagao-Eutr",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "incinerator",
+    "name": "Incinerator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "indium",
+    "name": "Indium",
+    "group": "resource",
+    "value": 132
+  },
+  {
+    "id": "indium_drive",
+    "name": "Indium Drive",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "industrial_barrel",
+    "name": "Industrial Barrel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "industrial_bench",
+    "name": "Industrial Bench",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "industrial_joint",
+    "name": "Industrial Joint",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "industrial_pallet",
+    "name": "Industrial Pallet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "industrial_pump",
+    "name": "Industrial Pump",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "industrial_room_expansion",
+    "name": "Industrial Room (Expansion)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "industrial_grade_battery",
+    "name": "Industrial-Grade Battery",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "inert_whelk",
+    "name": "Inert Whelk",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "infra_knife_accelerator",
+    "name": "Infra-Knife Accelerator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "infra_knife_accelerator_coolant_sigma",
+    "name": "Infra-Knife Accelerator Coolant Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "infra_knife_accelerator_coolant_tau",
+    "name": "Infra-Knife Accelerator Coolant Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "infra_knife_accelerator_coolant_theta",
+    "name": "Infra-Knife Accelerator Coolant Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "infra_knife_accelerator_damage_sigma",
+    "name": "Infra-Knife Accelerator Damage Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "infra_knife_accelerator_damage_tau",
+    "name": "Infra-Knife Accelerator Damage Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "infra_knife_accelerator_damage_theta",
+    "name": "Infra-Knife Accelerator Damage Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "infra_knife_accelerator_fire_rate_sigma",
+    "name": "Infra-Knife Accelerator Fire Rate Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "infra_knife_accelerator_fire_rate_tau",
+    "name": "Infra-Knife Accelerator Fire Rate Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "infra_knife_accelerator_fire_rate_theta",
+    "name": "Infra-Knife Accelerator Fire Rate Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "infra_knife_accelerator_upgrade",
+    "name": "Infra-Knife Accelerator Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "infrastructure_cube",
+    "name": "Infrastructure Cube",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "infrastructure_cylinder",
+    "name": "Infrastructure Cylinder",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "infrastructure_floor",
+    "name": "Infrastructure Floor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "infrastructure_ladder",
+    "name": "Infrastructure Ladder",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "infrastructure_sphere",
+    "name": "Infrastructure Sphere",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "infrastructure_wall",
+    "name": "Infrastructure Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "input_terminal",
+    "name": "Input Terminal",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "instability_drive",
+    "name": "Instability Drive",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "instability_injector",
+    "name": "Instability Injector",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "insulated_flask",
+    "name": "Insulated Flask",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "insulating_gel",
+    "name": "Insulating Gel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "interior_stairs",
+    "name": "Interior Stairs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "internal_freighter_wall",
+    "name": "Internal Freighter Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "internal_stairway",
+    "name": "Internal Stairway",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "interstellar_curiosity",
+    "name": "Interstellar Curiosity",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "interstellar_fancy",
+    "name": "Interstellar Fancy",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "interstellar_scanner",
+    "name": "Interstellar Scanner",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "inversion_of_ilkulovoma",
+    "name": "Inversion of Ilkulovoma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "inversion_of_prudiiwei_winse",
+    "name": "Inversion of Prudiiwei-Winse",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "inverted_brainfish",
+    "name": "Inverted Brainfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "inverted_mirror",
+    "name": "Inverted Mirror",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "inverted_snapper",
+    "name": "Inverted Snapper",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "ion_barrier",
+    "name": "Ion Barrier",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ion_battery",
+    "name": "Ion Battery",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ion_blast",
+    "name": "Ion Blast",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "ion_capacitor",
+    "name": "Ion Capacitor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ion_propulsion_v1",
+    "name": "Ion Propulsion V1",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "ion_sphere",
+    "name": "Ion Sphere",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ionised_clam",
+    "name": "Ionised Clam",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "ionised_cobalt",
+    "name": "Ionised Cobalt",
+    "group": "resource",
+    "value": 162
+  },
+  {
+    "id": "ionised_oyster",
+    "name": "Ionised Oyster",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "ioxinite",
+    "name": "Ioxinite",
+    "group": "resource",
+    "value": 0
+  },
+  {
+    "id": "iridesite",
+    "name": "Iridesite",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iridium",
+    "name": "Iridium",
+    "group": "resource",
+    "value": 96
+  },
+  {
+    "id": "iron",
+    "name": "Iron",
+    "group": "resource",
+    "value": 13.8
+  },
+  {
+    "id": "irregular_alloy_window",
+    "name": "Irregular Alloy Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "itching_creeping_honey_sponge",
+    "name": "Itching, Creeping Honey Sponge",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iteration_ares_visage",
+    "name": "Iteration: Ares Visage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iteration_ariadne_visage",
+    "name": "Iteration: Ariadne Visage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iteration_cronus_visage",
+    "name": "Iteration: Cronus Visage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iteration_eos_visage",
+    "name": "Iteration: Eos Visage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iteration_gemini_visage",
+    "name": "Iteration: Gemini Visage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iteration_helios_visage",
+    "name": "Iteration: Helios Visage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iteration_hesperus_visage",
+    "name": "Iteration: Hesperus Visage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iteration_hyperion_visage",
+    "name": "Iteration: Hyperion Visage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iteration_mercury_visage",
+    "name": "Iteration: Mercury Visage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iteration_perses_visage",
+    "name": "Iteration: Perses Visage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iteration_selene_visage",
+    "name": "Iteration: Selene Visage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "iteration_tethys_visage",
+    "name": "Iteration: Tethys Visage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "j_a_defiant_path",
+    "name": "J/A Defiant Path",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "jade_peas",
+    "name": "Jade Peas",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jam_curiosity",
+    "name": "Jam Curiosity",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jam_doughnut",
+    "name": "Jam Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jam_fluffer",
+    "name": "Jam Fluffer",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jam_oozers",
+    "name": "Jam Oozers",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jam_tart",
+    "name": "Jam Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jammy_burster",
+    "name": "Jammy Burster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jammy_rounds",
+    "name": "Jammy Rounds",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jellied_eel",
+    "name": "Jellied Eel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jellied_fur_tart",
+    "name": "Jellied Fur Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jelly_of_the_veil",
+    "name": "Jelly of the Veil",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jelly_prawn",
+    "name": "Jelly Prawn",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jellymeat",
+    "name": "Jellymeat",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jetpack",
+    "name": "Jetpack",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "jetpack_booster_sigma",
+    "name": "Jetpack Booster Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "jetpack_booster_tau",
+    "name": "Jetpack Booster Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "jetpack_booster_theta",
+    "name": "Jetpack Booster Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "juicy_grub",
+    "name": "Juicy Grub",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "juicy_thorax",
+    "name": "Juicy Thorax",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "jungle_redfin",
+    "name": "Jungle Redfin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "kaviraiji_cair_mark_ix",
+    "name": "Kaviraiji-Cair Mark IX",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "kelp_rice",
+    "name": "Kelp Rice",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "kelp_sac",
+    "name": "Kelp Sac",
+    "group": "resource",
+    "value": 41
+  },
+  {
+    "id": "kiln_fired_pot",
+    "name": "Kiln-Fired Pot",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "kineostream_thruster",
+    "name": "Kineostream Thruster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "kite_patterned_rug",
+    "name": "Kite-Patterned Rug",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ko",
+    "name": "Ko",
+    "group": "resource",
+    "value": 0
+  },
+  {
+    "id": "korvax_casing",
+    "name": "Korvax Casing",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "korvax_decal",
+    "name": "Korvax Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "korvax_guild_poster",
+    "name": "Korvax Guild Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "korvax_swirl_poster",
+    "name": "Korvax Swirl Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "l_shaped_corridor",
+    "name": "L-Shaped Corridor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "l_shaped_glass_tunnel",
+    "name": "L-Shaped Glass Tunnel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "l_skylight_timber_roof",
+    "name": "L-Skylight Timber Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "l75_4_subdued_theory",
+    "name": "L75-4 Subdued Theory",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "lab_lamp",
+    "name": "Lab Lamp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ladder",
+    "name": "Ladder",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ladder_module",
+    "name": "Ladder Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "lahariist_mark_xvii",
+    "name": "Lahariist Mark XVII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "lamp_post",
+    "name": "Lamp Post",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "lamptip_ray",
+    "name": "Lamptip Ray",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "land_disruptor",
+    "name": "Land Disruptor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "landing_gear",
+    "name": "Landing Gear",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "landing_pad",
+    "name": "Landing Pad",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "lantern",
+    "name": "Lantern",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_artifact_crate",
+    "name": "Large Artifact Crate",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_freighter_room_a",
+    "name": "Large Freighter Room A",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_freighter_room_b",
+    "name": "Large Freighter Room B",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_freighter_room_c",
+    "name": "Large Freighter Room C",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_glass_panel",
+    "name": "Large Glass Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_hydroponic_tray",
+    "name": "Large Hydroponic Tray",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_monitor_station",
+    "name": "Large Monitor Station",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_moulded_crate",
+    "name": "Large Moulded Crate",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_refiner",
+    "name": "Large Refiner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_rocket_tubes",
+    "name": "Large Rocket Tubes",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "large_scaffolding",
+    "name": "Large Scaffolding",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_storage_unit",
+    "name": "Large Storage Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_timber_double_window",
+    "name": "Large Timber Double Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_timber_triple_window",
+    "name": "Large Timber Triple Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_tyre",
+    "name": "Large Tyre",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_wedge",
+    "name": "Large Wedge",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "large_window",
+    "name": "Large Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "larval_core",
+    "name": "Larval Core",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "latticed_sinew",
+    "name": "Latticed Sinew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "launch_auto_charger",
+    "name": "Launch Auto-Charger",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "launch_thruster",
+    "name": "Launch Thruster",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "launch_thruster_upgrade",
+    "name": "Launch Thruster Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "lavascale_trout",
+    "name": "Lavascale Trout",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "leathery_tart",
+    "name": "Leathery Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "leg_meat",
+    "name": "Leg Meat",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "lemmium",
+    "name": "Lemmium",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "leopard_fruit",
+    "name": "Leopard-Fruit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "lesser_dustfin",
+    "name": "Lesser Dustfin",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "life_support",
+    "name": "Life Support",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "life_support_gel",
+    "name": "Life Support Gel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "life_support_module_sigma",
+    "name": "Life Support Module Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "life_support_module_tau",
+    "name": "Life Support Module Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "life_support_upgrade",
+    "name": "Life Support Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "light",
+    "name": "Light",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "light_box",
+    "name": "Light Box",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "light_fissure",
+    "name": "Light Fissure",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "light_scaffold",
+    "name": "Light Scaffold",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "light_table",
+    "name": "Light Table",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "liquid_explosive",
+    "name": "Liquid Explosive",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "liquid_sun",
+    "name": "Liquid Sun",
+    "group": "resource",
+    "value": 16
+  },
+  {
+    "id": "liquidator_body",
+    "name": "Liquidator Body",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "liquidator_left_arm",
+    "name": "Liquidator Left Arm",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "liquidator_legs",
+    "name": "Liquidator Legs",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "liquidator_right_arm",
+    "name": "Liquidator Right Arm",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "lithium",
+    "name": "Lithium",
+    "group": "resource",
+    "value": 72
+  },
+  {
+    "id": "livestock_unit",
+    "name": "Livestock Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "living_glass",
+    "name": "Living Glass",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "living_pearl",
+    "name": "Living Pearl",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "living_slime",
+    "name": "Living Slime",
+    "group": "resource",
+    "value": 20
+  },
+  {
+    "id": "living_wall",
+    "name": "Living Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "living_water",
+    "name": "Living Water",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "load_balancer",
+    "name": "Load Balancer",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "locked_crate",
+    "name": "Locked Crate",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "locker",
+    "name": "Locker",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "locking_mechanism",
+    "name": "Locking Mechanism",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "log_encryption_key",
+    "name": "Log Encryption Key",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "longjaw_snapper",
+    "name": "Longjaw Snapper",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "longshore_cowling",
+    "name": "Longshore Cowling",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "loom_damage",
+    "name": "Loom Damage",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "lost_anglers_rig",
+    "name": "Lost Angler's Rig",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "lost_artifact",
+    "name": "Lost Artifact",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "lost_bathysphere",
+    "name": "Lost Bathysphere",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "lubricant",
+    "name": "Lubricant",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "lucid_hunter_xix",
+    "name": "Lucid Hunter XIX",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "lucid_prayer_vi",
+    "name": "Lucid Prayer VI",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "lumpen_doughnut",
+    "name": "Lumpen Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "lumpy_brainstem",
+    "name": "Lumpy Brainstem",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mag_field_landing_thrusters",
+    "name": "Mag-Field Landing Thrusters",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "magma_shark",
+    "name": "Magma Shark",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "magmox",
+    "name": "Magmox",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "magnetic_lock",
+    "name": "Magnetic Lock",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "magnetic_resonator",
+    "name": "Magnetic Resonator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "magnetised_ferrite",
+    "name": "Magnetised Ferrite",
+    "group": "resource",
+    "value": 82
+  },
+  {
+    "id": "magno_gold",
+    "name": "Magno-Gold",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "magpulse_lure",
+    "name": "Magpulse Lure",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mandelbrot_worm",
+    "name": "Mandelbrot Worm",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "mantis_ray",
+    "name": "Mantis Ray",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "many_eyed_jellyfish",
+    "name": "Many-Eyed Jellyfish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "many_mouthed_lunker",
+    "name": "Many-Mouthed Lunker",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "marine_glowworm",
+    "name": "Marine Glowworm",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "marine_pie",
+    "name": "Marine Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "marine_rock",
+    "name": "Marine Rock",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "marine_shelter",
+    "name": "Marine Shelter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "marine_steak",
+    "name": "Marine Steak",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mark_of_the_denier",
+    "name": "Mark of the Denier",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mark_xix",
+    "name": "Mark XIX",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "marrow_bulb",
+    "name": "Marrow Bulb",
+    "group": "resource",
+    "value": 41
+  },
+  {
+    "id": "marrow_flesh",
+    "name": "Marrow Flesh",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "marrow_shark",
+    "name": "Marrow Shark",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "mass_accelerator",
+    "name": "Mass Accelerator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "master_circuit",
+    "name": "Master Circuit",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "master_circuit_frigate",
+    "name": "Master Circuit (Frigate)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "matter_beam",
+    "name": "Matter Beam",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mature_heart_node",
+    "name": "Mature Heart Node",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mature_neural_stem",
+    "name": "Mature Neural Stem",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mealworms",
+    "name": "Mealworms",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "meat_flakes",
+    "name": "Meat Flakes",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "meaty_chunks",
+    "name": "Meaty Chunks",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "meaty_wings",
+    "name": "Meaty Wings",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "medi_pod",
+    "name": "Medi-Pod",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "medium_refiner",
+    "name": "Medium Refiner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "medusa_class_reactor",
+    "name": "Medusa-Class Reactor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "megalodon",
+    "name": "Megalodon",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "megawatt_heater",
+    "name": "Megawatt Heater",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mellifluous_jellyfish",
+    "name": "Mellifluous Jellyfish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "melted_fuel_cell",
+    "name": "Melted Fuel Cell",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "memories_of_atlantid",
+    "name": "Memories Of Atlantid",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "memory_fragment",
+    "name": "Memory Fragment",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "memory_imprint",
+    "name": "Memory Imprint",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "memory_resonator",
+    "name": "Memory Resonator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mercurial_angle_vi",
+    "name": "Mercurial Angle VI",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mesh_decouplers",
+    "name": "Mesh Decouplers",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "message_in_a_bottle",
+    "name": "Message in a Bottle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "message_module",
+    "name": "Message Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_arch",
+    "name": "Metal Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_door_frame",
+    "name": "Metal Door Frame",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_doorway",
+    "name": "Metal Doorway",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_floor_panel",
+    "name": "Metal Floor Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_frontage",
+    "name": "Metal Frontage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_half_arch",
+    "name": "Metal Half Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_half_ramp",
+    "name": "Metal Half Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_inner_roof_corner",
+    "name": "Metal Inner Roof Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_plating",
+    "name": "Metal Plating",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_power_door",
+    "name": "Metal Power Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_ramp",
+    "name": "Metal Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_roof",
+    "name": "Metal Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_roof_corner",
+    "name": "Metal Roof Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_roof_panel",
+    "name": "Metal Roof Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_triangle",
+    "name": "Metal Triangle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_wall",
+    "name": "Metal Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_window_panel",
+    "name": "Metal Window Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metal_framed_glass_panel",
+    "name": "Metal-Framed Glass Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "metallic_shrimp",
+    "name": "Metallic Shrimp",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "meteorological_spinner",
+    "name": "Meteorological Spinner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "methane",
+    "name": "Methane",
+    "group": "resource",
+    "value": 35
+  },
+  {
+    "id": "microdensity_fabric",
+    "name": "Microdensity Fabric",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "microprocessor",
+    "name": "Microprocessor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "midnight_eel",
+    "name": "Midnight Eel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mind_ark",
+    "name": "Mind Ark",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mind_control_device",
+    "name": "Mind Control Device",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "minelaser",
+    "name": "MineLaser",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mineral_arch",
+    "name": "Mineral Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mineral_compressor",
+    "name": "Mineral Compressor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mineral_extractor",
+    "name": "Mineral Extractor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mineral_processing_rig",
+    "name": "Mineral Processing Rig",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mini_weathered_hanging",
+    "name": "Mini Weathered Hanging",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mining_beam",
+    "name": "Mining Beam",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mining_beam_atlas",
+    "name": "Mining Beam (Atlas)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mining_beam_upgrade",
+    "name": "Mining Beam Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "minotaur_ai_pilot",
+    "name": "Minotaur AI Pilot",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "minotaur_bore",
+    "name": "Minotaur Bore",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "minotaur_cannon",
+    "name": "Minotaur Cannon",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "minotaur_cannon_upgrade",
+    "name": "Minotaur Cannon Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "minotaur_flamethrower_upgrade",
+    "name": "Minotaur Flamethrower Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "minotaur_geobay",
+    "name": "Minotaur Geobay",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "minotaur_laser",
+    "name": "Minotaur Laser",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "minotaur_laser_upgrade",
+    "name": "Minotaur Laser Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "minotaur_radar_array",
+    "name": "Minotaur Radar Array",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mirrorscale_skipper",
+    "name": "Mirrorscale Skipper",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mission_radar",
+    "name": "Mission Radar",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mist_serpent",
+    "name": "Mist Serpent",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "modified_quanta",
+    "name": "Modified Quanta",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mollusc_flesh",
+    "name": "Mollusc Flesh",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "monitor_station",
+    "name": "Monitor Station",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "monstrous_custard",
+    "name": "Monstrous Custard",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "monstrous_doughnut",
+    "name": "Monstrous Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "monstrous_honey_cake",
+    "name": "Monstrous Honey Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "moon_ether",
+    "name": "Moon Ether",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "moon_pool_floor",
+    "name": "Moon Pool Floor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "moon_turtle",
+    "name": "Moon Turtle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mordite",
+    "name": "Mordite",
+    "group": "resource",
+    "value": 40
+  },
+  {
+    "id": "mordite_root",
+    "name": "Mordite Root",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "moskojin_xorc_mark_xviii",
+    "name": "Moskojin-Xorc Mark XVIII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "most_curious_cake",
+    "name": "Most Curious Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mother_of_quicksilver",
+    "name": "Mother-of-Quicksilver",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "moulded_crate",
+    "name": "Moulded Crate",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "moulded_lockbox",
+    "name": "Moulded Lockbox",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mounted_cannon",
+    "name": "Mounted Cannon",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mounted_cannon_upgrade",
+    "name": "Mounted Cannon Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mounted_cannon_upgrade_sigma",
+    "name": "Mounted Cannon Upgrade Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mounted_flamethrower",
+    "name": "Mounted Flamethrower",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "movement_system_upgrade",
+    "name": "Movement System Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "mucal_curiosity",
+    "name": "Mucal Curiosity",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mucal_doughnut",
+    "name": "Mucal Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "muculent_tart",
+    "name": "Muculent Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mud_crab",
+    "name": "Mud Crab",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mud_hut",
+    "name": "Mud Hut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "multi_tool_expansion_slot",
+    "name": "Multi-Tool Expansion Slot",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "murmurfish",
+    "name": "Murmurfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "murrine",
+    "name": "Murrine",
+    "group": "resource",
+    "value": 303
+  },
+  {
+    "id": "mushed_root_pie",
+    "name": "Mushed Root Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mystery_meat_pie",
+    "name": "Mystery Meat Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "mystery_meat_stew",
+    "name": "Mystery Meat Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "myth_beacon",
+    "name": "Myth Beacon",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nada_decal",
+    "name": "Nada Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nada_figurine",
+    "name": "Nada Figurine",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nanite_cluster",
+    "name": "Nanite Cluster",
+    "group": "resource",
+    "value": 0
+  },
+  {
+    "id": "nanotube_crate",
+    "name": "Nanotube Crate",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nautilia",
+    "name": "Nautilia",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nautilon_cannon",
+    "name": "Nautilon Cannon",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "nautilon_cannon_upgrade",
+    "name": "Nautilon Cannon Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "nautilon_chamber",
+    "name": "Nautilon Chamber",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "navigation_data",
+    "name": "Navigation Data",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nectar_islands",
+    "name": "Nectar Islands",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nectar_sponge_cake",
+    "name": "Nectar Sponge Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "needlefish",
+    "name": "Needlefish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "network_interface",
+    "name": "Network Interface",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "neural_assembly",
+    "name": "Neural Assembly",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "neural_duct",
+    "name": "Neural Duct",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "neural_shielding",
+    "name": "Neural Shielding",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "neural_shielding_implant",
+    "name": "Neural Shielding Implant",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "neural_stimulator",
+    "name": "Neural Stimulator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "neutrino_module",
+    "name": "Neutrino Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "neutron_cannon",
+    "name": "Neutron Cannon",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "neutron_cannon_upgrade",
+    "name": "Neutron Cannon Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "neutron_microscope",
+    "name": "Neutron Microscope",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "neutron_shielding",
+    "name": "Neutron Shielding",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "nickel",
+    "name": "Nickel",
+    "group": "resource",
+    "value": 138
+  },
+  {
+    "id": "night_crystals",
+    "name": "Night Crystals",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nightmare_sausage",
+    "name": "Nightmare Sausage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nipnip",
+    "name": "NipNip",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nipnip_buds",
+    "name": "NipNip Buds",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nitrogen",
+    "name": "Nitrogen",
+    "group": "resource",
+    "value": 20
+  },
+  {
+    "id": "nitrogen_salt",
+    "name": "Nitrogen Salt",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nm5_iq7_complete_angle",
+    "name": "NM5-IQ7 Complete Angle",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "noise_box",
+    "name": "Noise Box",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "non_euclidean_flatfish",
+    "name": "Non-Euclidean Flatfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "non_ferrous_plate",
+    "name": "Non-ferrous Plate",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "non_stick_piston",
+    "name": "Non-Stick Piston",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "non_toxic_mushroom",
+    "name": "Non-Toxic Mushroom",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nonlinear_optics",
+    "name": "Nonlinear Optics",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "nonlinear_optics_infra_knife_accelerator",
+    "name": "Nonlinear Optics (Infra-Knife Accelerator)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "noospheric_orb",
+    "name": "Noospheric Orb",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nourishing_oozer",
+    "name": "Nourishing Oozer",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nourishing_slime",
+    "name": "Nourishing Slime",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "novae_reclaiment",
+    "name": "Novae Reclaiment",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nucleic_skipper",
+    "name": "Nucleic Skipper",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "null_decal",
+    "name": "Null Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nutrient_ingestor",
+    "name": "Nutrient Ingestor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "nutrient_processor",
+    "name": "Nutrient Processor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nutrition_room",
+    "name": "Nutrition Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "nutrition_unit",
+    "name": "Nutrition Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "o_l_complete_inversion",
+    "name": "O/L Complete Inversion",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "obedient_loop_xvii",
+    "name": "Obedient Loop XVII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "obsolete_technology",
+    "name": "Obsolete Technology",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "octa_cabinet",
+    "name": "Octa-Cabinet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "odvinsko_iayi_v7_28",
+    "name": "Odvinsko-Iayi V7.28",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "oebardsub_lesc_mark_xiii",
+    "name": "Oebardsub Lesc Mark XIII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "offal_sac",
+    "name": "Offal Sac",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ofitsial_uilo_v4_0",
+    "name": "Ofitsial uilo V4.0",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "ogliaobei_urge_mark_xiii",
+    "name": "Ogliaobei-Urge Mark XIII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "ohmic_gel",
+    "name": "Ohmic Gel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "oil_burner",
+    "name": "Oil Burner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "oilfin",
+    "name": "Oilfin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "old_boot",
+    "name": "Old Boot",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "omegon",
+    "name": "Omegon",
+    "group": "resource",
+    "value": 309
+  },
+  {
+    "id": "omelette",
+    "name": "Omelette",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "once_useful_springs",
+    "name": "Once-Useful Springs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "open_moulded_lockbox",
+    "name": "Open Moulded Lockbox",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "open_tall_moulded_lockbox",
+    "name": "Open Tall Moulded Lockbox",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "optical_drill",
+    "name": "Optical Drill",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "optical_solvent",
+    "name": "Optical Solvent",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "opulent_tapestry",
+    "name": "Opulent Tapestry",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "orange_pustule",
+    "name": "Orange Pustule",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "orange_wall_screen",
+    "name": "Orange Wall Screen",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "orbital_exocraft_materialiser",
+    "name": "Orbital Exocraft Materialiser",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "organic_catalyst",
+    "name": "Organic Catalyst",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "organic_piping",
+    "name": "Organic Piping",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ornate_stool",
+    "name": "Ornate Stool",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "oscilloscope",
+    "name": "Oscilloscope",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "osmotic_generator",
+    "name": "Osmotic Generator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "osprey_wing_module",
+    "name": "Osprey Wing Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ossified_coral",
+    "name": "Ossified Coral",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ossified_deinosuchus",
+    "name": "Ossified Deinosuchus",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "ossified_star",
+    "name": "Ossified Star",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "output_screen",
+    "name": "Output Screen",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "oxycen",
+    "name": "Oxycen",
+    "group": "resource",
+    "value": 0
+  },
+  {
+    "id": "oxygen",
+    "name": "Oxygen",
+    "group": "resource",
+    "value": 34
+  },
+  {
+    "id": "oxygen_capsule",
+    "name": "Oxygen Capsule",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "oxygen_filter",
+    "name": "Oxygen Filter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "oxygen_harvester",
+    "name": "Oxygen Harvester",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "oxygen_recycler",
+    "name": "Oxygen Recycler",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "oxygen_rerouter",
+    "name": "Oxygen Rerouter",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "p_field_compressor",
+    "name": "P-Field Compressor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pail",
+    "name": "Pail",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pale_snowtail",
+    "name": "Pale Snowtail",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "panelled_timber_divider",
+    "name": "Panelled Timber Divider",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "panelled_window",
+    "name": "Panelled Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "paraffinium",
+    "name": "Paraffinium",
+    "group": "resource",
+    "value": 62
+  },
+  {
+    "id": "paralysis_mortar",
+    "name": "Paralysis Mortar",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "parasitic_omelette",
+    "name": "Parasitic Omelette",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "partially_liquid_cheese",
+    "name": "Partially-Liquid Cheese",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pastry",
+    "name": "Pastry",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "path_of_devertage_noff",
+    "name": "Path of Devertage-Noff",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "path_of_deyneseg",
+    "name": "Path of Deyneseg",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pawprints_poster",
+    "name": "Pawprints Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pearl_offering",
+    "name": "Pearl Offering",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "peeled_claws",
+    "name": "Peeled Claws",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "perpetual_cake",
+    "name": "Perpetual Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "perpetual_honeycake",
+    "name": "Perpetual Honeycake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "perpetual_ice_cream",
+    "name": "Perpetual Ice Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "perpetual_jam_fluffer",
+    "name": "Perpetual Jam Fluffer",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "personal_forcefield",
+    "name": "Personal Forcefield",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "personal_refiner",
+    "name": "Personal Refiner",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "personal_refiner_mk_2",
+    "name": "Personal Refiner Mk 2",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "phase_beam",
+    "name": "Phase Beam",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "phase_beam_atlas",
+    "name": "Phase Beam (Atlas)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "phase_beam_array",
+    "name": "Phase Beam Array",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "phase_beam_upgrade",
+    "name": "Phase Beam Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "phase_coolant_sigma",
+    "name": "Phase Coolant Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "phase_coolant_tau",
+    "name": "Phase Coolant Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "phase_coolant_theta",
+    "name": "Phase Coolant Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pheromone_sac",
+    "name": "Pheromone Sac",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "phosphorus",
+    "name": "Phosphorus",
+    "group": "resource",
+    "value": 62
+  },
+  {
+    "id": "photic_jade",
+    "name": "Photic Jade",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "photon_accelerator",
+    "name": "Photon Accelerator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "photon_blast",
+    "name": "Photon Blast",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "photon_cannon",
+    "name": "Photon Cannon",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "photon_cannon_array",
+    "name": "Photon Cannon Array",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "photon_cannon_upgrade",
+    "name": "Photon Cannon Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "photonix_core",
+    "name": "Photonix Core",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "photovoltaic_panel",
+    "name": "Photovoltaic Panel",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "photovoltaic_panel_frigate",
+    "name": "Photovoltaic Panel (Frigate)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pickled_fish",
+    "name": "Pickled Fish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pie_case",
+    "name": "Pie Case",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pilgrim_geobay",
+    "name": "Pilgrim Geobay",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pilgrims_tonic",
+    "name": "Pilgrim's Tonic",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pilgrimberry",
+    "name": "Pilgrimberry",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pilyusha_mark_vi",
+    "name": "Pilyusha Mark VI",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pipe",
+    "name": "Pipe",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pirate_transponder",
+    "name": "Pirate Transponder",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "planetary_chart_ancient_artifact_site",
+    "name": "Planetary Chart (ancient artifact site)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "planetary_chart_distress_signal",
+    "name": "Planetary Chart (distress signal)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "planetary_chart_empty",
+    "name": "Planetary Chart (Empty)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "planetary_chart_inhabited_outpost",
+    "name": "Planetary Chart (inhabited outpost)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "planetary_chart_secure_site",
+    "name": "Planetary Chart (secure site)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "planetary_globe",
+    "name": "Planetary Globe",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "plasma_core",
+    "name": "Plasma Core",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "plasma_core_casing_v1",
+    "name": "Plasma Core Casing V1",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "plasma_launcher",
+    "name": "Plasma Launcher",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "plasma_launcher_upgrade",
+    "name": "Plasma Launcher Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "plasma_resonator",
+    "name": "Plasma Resonator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "plasmatic_squid",
+    "name": "Plasmatic Squid",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "plasmatic_warp_injector",
+    "name": "Plasmatic Warp Injector",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "plate_stem",
+    "name": "Plate Stem",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "platinum",
+    "name": "Platinum",
+    "group": "resource",
+    "value": 505
+  },
+  {
+    "id": "plutonium",
+    "name": "Plutonium",
+    "group": "resource",
+    "value": 41
+  },
+  {
+    "id": "poached_worms",
+    "name": "Poached Worms",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pocket_reality_generator",
+    "name": "Pocket Reality Generator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "polished_stone",
+    "name": "Polished Stone",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pollen_puffball",
+    "name": "Pollen Puffball",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "polo_decal",
+    "name": "Polo Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "polo_figurine",
+    "name": "Polo Figurine",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "poly_fibre",
+    "name": "Poly Fibre",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "polychromatic_zirconium",
+    "name": "Polychromatic Zirconium",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "polyphonic_core",
+    "name": "Polyphonic Core",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pondskipper",
+    "name": "Pondskipper",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "popping_stew",
+    "name": "Popping Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "portable_reactor",
+    "name": "Portable Reactor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "portable_refiner",
+    "name": "Portable Refiner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "positron_ejector",
+    "name": "Positron Ejector",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "positron_ejector_atlas",
+    "name": "Positron Ejector (Atlas)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "positron_ejector_coolant_sigma",
+    "name": "Positron Ejector Coolant Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "positron_ejector_coolant_tau",
+    "name": "Positron Ejector Coolant Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "positron_ejector_coolant_theta",
+    "name": "Positron Ejector Coolant Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "positron_ejector_damage_sigma",
+    "name": "Positron Ejector Damage Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "positron_ejector_damage_tau",
+    "name": "Positron Ejector Damage Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "positron_ejector_damage_theta",
+    "name": "Positron Ejector Damage Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "positron_ejector_fire_rate_sigma",
+    "name": "Positron Ejector Fire Rate Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "positron_ejector_fire_rate_tau",
+    "name": "Positron Ejector Fire Rate Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "positron_ejector_fire_rate_theta",
+    "name": "Positron Ejector Fire Rate Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "positron_ejector_upgrade",
+    "name": "Positron Ejector Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "potted_plant",
+    "name": "Potted Plant",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "power_canister",
+    "name": "Power Canister",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "power_distributor",
+    "name": "Power Distributor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "power_distributor_frigate",
+    "name": "Power Distributor (Frigate)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "power_gel",
+    "name": "Power Gel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "power_inverter",
+    "name": "Power Inverter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "power_reservoir",
+    "name": "Power Reservoir",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "prayer_of_kaladeela_dedar",
+    "name": "Prayer of Kaladeela Dedar",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "precision_minotaur_laser",
+    "name": "Precision Minotaur Laser",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pressure_chamber",
+    "name": "Pressure Chamber",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pressure_chamber_frigate",
+    "name": "Pressure Chamber (Frigate)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pressure_membrane",
+    "name": "Pressure Membrane",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pressurised_clam",
+    "name": "Pressurised Clam",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "prickly_curiosity",
+    "name": "Prickly Curiosity",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "primordial_sponge",
+    "name": "Primordial Sponge",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "prismatic_feathers",
+    "name": "Prismatic Feathers",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "processed_meat",
+    "name": "Processed Meat",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "processed_sugar",
+    "name": "Processed Sugar",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "projectile_ammunition",
+    "name": "Projectile Ammunition",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "propped_flag_divider",
+    "name": "Propped Flag Divider",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "propped_timber_divider",
+    "name": "Propped Timber Divider",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "propped_timber_dividers",
+    "name": "Propped Timber Dividers",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "protea_wheel",
+    "name": "Protea Wheel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "protection_mesh",
+    "name": "Protection Mesh",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "proteinous_doughnut",
+    "name": "Proteinous Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "proto_batter",
+    "name": "Proto-Batter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "proto_beignet",
+    "name": "Proto-Beignet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "proto_butter",
+    "name": "Proto-Butter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "proto_cream",
+    "name": "Proto-Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "proto_oil",
+    "name": "Proto-Oil",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "proto_omelette",
+    "name": "Proto-Omelette",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "proto_sausage_pie",
+    "name": "Proto-Sausage Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "protocheese",
+    "name": "ProtoCheese",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "protosausage",
+    "name": "ProtoSausage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "proximity_switch",
+    "name": "Proximity Switch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "psychonic_egg",
+    "name": "Psychonic Egg",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pugneum",
+    "name": "Pugneum",
+    "group": "resource",
+    "value": 138
+  },
+  {
+    "id": "pulpy_roots",
+    "name": "Pulpy Roots",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pulsating_core",
+    "name": "Pulsating Core",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pulse_engine",
+    "name": "Pulse Engine",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_engine_upgrade",
+    "name": "Pulse Engine Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_jet_sigma",
+    "name": "Pulse Jet Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_jet_tau",
+    "name": "Pulse Jet Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter",
+    "name": "Pulse Spitter",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter_atlas",
+    "name": "Pulse Spitter (Atlas)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter_accuracy_sigma",
+    "name": "Pulse Spitter Accuracy Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter_accuracy_tau",
+    "name": "Pulse Spitter Accuracy Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter_accuracy_theta",
+    "name": "Pulse Spitter Accuracy Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter_damage_sigma",
+    "name": "Pulse Spitter Damage Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter_damage_tau",
+    "name": "Pulse Spitter Damage Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter_damage_theta",
+    "name": "Pulse Spitter Damage Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter_reload_sigma",
+    "name": "Pulse Spitter Reload Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter_reload_tau",
+    "name": "Pulse Spitter Reload Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter_reload_theta",
+    "name": "Pulse Spitter Reload Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter_ricochet_module",
+    "name": "Pulse Spitter Ricochet Module",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulse_spitter_upgrade",
+    "name": "Pulse Spitter Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pulsing_heart",
+    "name": "Pulsing Heart",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "pure_ferrite",
+    "name": "Pure Ferrite",
+    "group": "resource",
+    "value": 28
+  },
+  {
+    "id": "purged_ribs",
+    "name": "Purged Ribs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pyramid",
+    "name": "Pyramid",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "pyrefin",
+    "name": "Pyrefin",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "pyrite",
+    "name": "Pyrite",
+    "group": "resource",
+    "value": 62
+  },
+  {
+    "id": "pyrodrive_booster",
+    "name": "Pyrodrive Booster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "q_resonator",
+    "name": "Q-Resonator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "qitanian_empire_decal",
+    "name": "Qitanian Empire Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "quad_flag_divider",
+    "name": "Quad Flag Divider",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "quad_servo",
+    "name": "Quad Servo",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "quantum_accelerator",
+    "name": "Quantum Accelerator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "quantum_computer",
+    "name": "Quantum Computer",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "quantum_processor",
+    "name": "Quantum Processor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "quartzite",
+    "name": "Quartzite",
+    "group": "resource",
+    "value": 132
+  },
+  {
+    "id": "questionable_biscuit",
+    "name": "Questionable Biscuit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "questionably_sweet_cake",
+    "name": "Questionably Sweet Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "qv6_r_lucid_clarity",
+    "name": "QV6-R Lucid Clarity",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "qw17_elevated_trace",
+    "name": "QW17 Elevated Trace",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "race_force_amplifier",
+    "name": "Race Force Amplifier",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "race_initiator",
+    "name": "Race Initiator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "race_obstacle",
+    "name": "Race Obstacle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "radar_amplifier",
+    "name": "Radar Amplifier",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "radar_dome",
+    "name": "Radar Dome",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "radar_power_resonator",
+    "name": "Radar Power Resonator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "radiant_brain",
+    "name": "Radiant Brain",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "radiant_shard",
+    "name": "Radiant Shard",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "radiant_sunfish",
+    "name": "Radiant Sunfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "radiation_deflector",
+    "name": "Radiation Deflector",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "radiation_deflector_next",
+    "name": "Radiation Deflector (NEXT)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "radiation_deflector_sigma",
+    "name": "Radiation Deflector Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "radiation_deflector_tau",
+    "name": "Radiation Deflector Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "radiation_deflector_theta",
+    "name": "Radiation Deflector Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "radiation_leak",
+    "name": "Radiation Leak",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "radiation_protection_module",
+    "name": "Radiation Protection Module",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "radiation_protection_upgrade",
+    "name": "Radiation Protection Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "radiator_casing",
+    "name": "Radiator Casing",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "radiator_vent",
+    "name": "Radiator Vent",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "radnox",
+    "name": "Radnox",
+    "group": "resource",
+    "value": 303
+  },
+  {
+    "id": "radon",
+    "name": "Radon",
+    "group": "resource",
+    "value": 20
+  },
+  {
+    "id": "raegon_214",
+    "name": "Raegon-214",
+    "group": "resource",
+    "value": 0
+  },
+  {
+    "id": "railshot_adaptor",
+    "name": "Railshot Adaptor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "raised_platform_alloy_roof",
+    "name": "Raised Platform Alloy Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "raised_small_paving",
+    "name": "Raised Small Paving",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rancid_flesh",
+    "name": "Rancid Flesh",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rangeboost_sigma",
+    "name": "RangeBoost Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rangeboost_tau",
+    "name": "RangeBoost Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rapidfire_sigma",
+    "name": "Rapidfire Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rapidfire_tau",
+    "name": "Rapidfire Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rapidfire_theta",
+    "name": "Rapidfire Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rare_metal_element",
+    "name": "Rare Metal Element",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rattle_spine",
+    "name": "Rattle Spine",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "raw_steak",
+    "name": "Raw Steak",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "re_latticed_arc_crystal",
+    "name": "Re-latticed Arc Crystal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "reactor_core",
+    "name": "Reactor Core",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "reality_de_threader",
+    "name": "Reality De-Threader",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rebound_grenades",
+    "name": "Rebound Grenades",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rebound_grenades_tau",
+    "name": "Rebound Grenades Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rebuilt_exosuit_module",
+    "name": "Rebuilt Exosuit Module",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "recoil_stabiliser_sigma",
+    "name": "Recoil Stabiliser Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "recoil_stabiliser_tau",
+    "name": "Recoil Stabiliser Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "recoil_stabiliser_theta",
+    "name": "Recoil Stabiliser Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "recovered_item_cog",
+    "name": "Recovered Item (COG)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "recovered_item_data",
+    "name": "Recovered Item (DATA)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "recovered_item_lump",
+    "name": "Recovered Item (LUMP)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "recovered_message",
+    "name": "Recovered Message",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "recycled_circuitry",
+    "name": "Recycled Circuitry",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "red_canister",
+    "name": "Red Canister",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "red_design_decal",
+    "name": "Red Design Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "red_firework",
+    "name": "Red Firework",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "reef_eel",
+    "name": "Reef Eel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "reef_guardian",
+    "name": "Reef Guardian",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "refined_flour",
+    "name": "Refined Flour",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "refiner_room",
+    "name": "Refiner Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "refiner_unit",
+    "name": "Refiner Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "reflex_aspect_xi",
+    "name": "Reflex Aspect XI",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "reflex_elutisti",
+    "name": "Reflex Elutisti",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "reflex_thagrenbo_xopre",
+    "name": "Reflex Thagrenbo-Xopre",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "refreshing_drink",
+    "name": "Refreshing Drink",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "regis_grease",
+    "name": "Regis Grease",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "reinforced_capsule",
+    "name": "Reinforced Capsule",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "reinforced_hull_link",
+    "name": "Reinforced Hull Link",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "reinforced_piping",
+    "name": "Reinforced Piping",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "reinforced_window",
+    "name": "Reinforced Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "relay_joint",
+    "name": "Relay Joint",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "reload_accelerant_sigma",
+    "name": "Reload Accelerant Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "reload_accelerant_tau",
+    "name": "Reload Accelerant Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "reload_accelerant_theta",
+    "name": "Reload Accelerant Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "remembrance",
+    "name": "Remembrance",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "remembrance_terminal",
+    "name": "Remembrance Terminal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rendezvous_beacon",
+    "name": "Rendezvous Beacon",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "repair_kit",
+    "name": "Repair Kit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "residual_goop",
+    "name": "Residual Goop",
+    "group": "resource",
+    "value": 20
+  },
+  {
+    "id": "resonance_amplifier",
+    "name": "Resonance Amplifier",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "resonance_matrix",
+    "name": "Resonance Matrix",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "retort_of_ryforbag",
+    "name": "Retort of Ryforbag",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "return_of_otusiret_fuma",
+    "name": "Return of Otusiret-Fuma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "ricochet_sigma",
+    "name": "Ricochet Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "ricochet_tau",
+    "name": "Ricochet Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "ricochet_theta",
+    "name": "Ricochet Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rimescale_snapper",
+    "name": "Rimescale Snapper",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "riposte_of_daukaint",
+    "name": "Riposte of Daukaint",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "riposte_of_issaphan",
+    "name": "Riposte of Issaphan",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "roamer_geobay",
+    "name": "Roamer Geobay",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "robotic_arm",
+    "name": "Robotic Arm",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "robotic_companion",
+    "name": "Robotic Companion",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rock_garden",
+    "name": "Rock Garden",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rocket_boots",
+    "name": "Rocket Boots",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rocket_launcher",
+    "name": "Rocket Launcher",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rockfin",
+    "name": "Rockfin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rockhopper_fin_module",
+    "name": "Rockhopper Fin Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rockhopper_propeller_module",
+    "name": "Rockhopper Propeller Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rockhopper_wing_module",
+    "name": "Rockhopper Wing Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rolled_canvas",
+    "name": "Rolled Canvas",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rolled_canvas_pile",
+    "name": "Rolled Canvas Pile",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "root_juice",
+    "name": "Root Juice",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "round_table",
+    "name": "Round Table",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rounded_flat_stone_roof",
+    "name": "Rounded Flat Stone Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rounded_flat_timber_glass_roof",
+    "name": "Rounded Flat Timber-Glass Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rounded_standing_light",
+    "name": "Rounded Standing Light",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rounded_timber_roof",
+    "name": "Rounded Timber Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rounded_window",
+    "name": "Rounded Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "rubeum",
+    "name": "Rubeum",
+    "group": "resource",
+    "value": 288.8
+  },
+  {
+    "id": "runaway_mould",
+    "name": "Runaway Mould",
+    "group": "resource",
+    "value": 20
+  },
+  {
+    "id": "rusted_circuits",
+    "name": "Rusted Circuits",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rusted_metal",
+    "name": "Rusted Metal",
+    "group": "resource",
+    "value": 20
+  },
+  {
+    "id": "rusted_power_core",
+    "name": "Rusted Power Core",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "rusted_technology",
+    "name": "Rusted Technology",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sac_venom",
+    "name": "Sac Venom",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "safety_panel",
+    "name": "Safety Panel",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "sail_palm",
+    "name": "Sail Palm",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "saline_carapace",
+    "name": "Saline Carapace",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "salt",
+    "name": "Salt",
+    "group": "resource",
+    "value": 101
+  },
+  {
+    "id": "salt_refractor",
+    "name": "Salt Refractor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salt_laced_honey_cake",
+    "name": "Salt-Laced Honey Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salty_chunks",
+    "name": "Salty Chunks",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salty_cruncher",
+    "name": "Salty Cruncher",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salty_custard",
+    "name": "Salty Custard",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salty_doughnut",
+    "name": "Salty Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salty_fingers",
+    "name": "Salty Fingers",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salty_juice",
+    "name": "Salty Juice",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salty_surprise",
+    "name": "Salty Surprise",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salvage_container",
+    "name": "Salvage Container",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salvage_crate",
+    "name": "Salvage Crate",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salvaged_data",
+    "name": "Salvaged Data",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salvaged_fleet_unit",
+    "name": "Salvaged Fleet Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salvaged_frigate_module",
+    "name": "Salvaged Frigate Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salvaged_glass",
+    "name": "Salvaged Glass",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salvaged_scrap",
+    "name": "Salvaged Scrap",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "salvaged_upgrade_components",
+    "name": "Salvaged Upgrade Components",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "sample_containment",
+    "name": "Sample Containment",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "satellite_receiver",
+    "name": "Satellite Receiver",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "save_beacon",
+    "name": "Save Beacon",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "save_point",
+    "name": "Save Point",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "scaffolding",
+    "name": "Scaffolding",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "scaly_meat",
+    "name": "Scaly Meat",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "scan_harmoniser",
+    "name": "Scan Harmoniser",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scanner",
+    "name": "Scanner",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scanner_room",
+    "name": "Scanner Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster",
+    "name": "Scatter Blaster",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_accuracy_sigma",
+    "name": "Scatter Blaster Accuracy Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_accuracy_tau",
+    "name": "Scatter Blaster Accuracy Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_accuracy_theta",
+    "name": "Scatter Blaster Accuracy Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_capacity_sigma",
+    "name": "Scatter Blaster Capacity Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_capacity_tau",
+    "name": "Scatter Blaster Capacity Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_capacity_theta",
+    "name": "Scatter Blaster Capacity Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_damage_sigma",
+    "name": "Scatter Blaster Damage Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_damage_tau",
+    "name": "Scatter Blaster Damage Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_damage_theta",
+    "name": "Scatter Blaster Damage Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_reload_sigma",
+    "name": "Scatter Blaster Reload Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_reload_tau",
+    "name": "Scatter Blaster Reload Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_reload_theta",
+    "name": "Scatter Blaster Reload Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scatter_blaster_upgrade",
+    "name": "Scatter Blaster Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scented_herbs",
+    "name": "Scented Herbs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "science_specialists_room",
+    "name": "Science Specialist's Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "science_terminal",
+    "name": "Science Terminal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "scissor_lift",
+    "name": "Scissor Lift",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "scooped_innards",
+    "name": "Scooped Innards",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "scorched_plating",
+    "name": "Scorched Plating",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "scorching_sauce",
+    "name": "Scorching Sauce",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "scorpionfish",
+    "name": "Scorpionfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "scrambled_marrow",
+    "name": "Scrambled Marrow",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "scream_suppressor",
+    "name": "Scream Suppressor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "screaming_crab",
+    "name": "Screaming Crab",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "sea_cucumber",
+    "name": "Sea Cucumber",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sea_glass",
+    "name": "Sea Glass",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sea_sponge",
+    "name": "Sea Sponge",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "seafood_stew",
+    "name": "Seafood Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sealed_barrel",
+    "name": "Sealed Barrel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sealed_reservoir",
+    "name": "Sealed Reservoir",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sealed_sea_chest",
+    "name": "Sealed Sea Chest",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "seamless_window",
+    "name": "Seamless Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "seared_fillet",
+    "name": "Seared Fillet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "secure_briefcase",
+    "name": "Secure Briefcase",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "security_alarm",
+    "name": "Security Alarm",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "security_credentials",
+    "name": "Security Credentials",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "seeds_of_glass",
+    "name": "Seeds of Glass",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "seeping_pie",
+    "name": "Seeping Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "self_greasing_servos",
+    "name": "Self-Greasing Servos",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "self_repairing_heridium",
+    "name": "Self-Repairing Heridium",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "semiconductor",
+    "name": "Semiconductor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sentinel_boundary_map",
+    "name": "Sentinel Boundary Map",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sentinel_exosuit_fragment",
+    "name": "Sentinel Exosuit Fragment",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "sentinel_flare",
+    "name": "Sentinel Flare",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sentinel_weapons_shard",
+    "name": "Sentinel Weapons Shard",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "server",
+    "name": "Server",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "servo_arm",
+    "name": "Servo Arm",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "servo_arm_frigate",
+    "name": "Servo Arm (Frigate)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "settlement_chart",
+    "name": "Settlement Chart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shadow_lure",
+    "name": "Shadow Lure",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shadow_of_eharasaki",
+    "name": "Shadow of Eharasaki",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "shadowfin",
+    "name": "Shadowfin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shattered_bulwark",
+    "name": "Shattered Bulwark",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "shattered_power_core",
+    "name": "Shattered Power Core",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "shelf_panel",
+    "name": "Shelf Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shell_greaser",
+    "name": "Shell Greaser",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "shell_puree",
+    "name": "Shell Puree",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shield_kinetics",
+    "name": "Shield Kinetics",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "shield_lattice",
+    "name": "Shield Lattice",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "shield_station",
+    "name": "Shield Station",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shieldboost_sigma",
+    "name": "ShieldBoost Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "shieldboost_tau",
+    "name": "ShieldBoost Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "shieldboost_theta",
+    "name": "ShieldBoost Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "shieldboost_v1",
+    "name": "ShieldBoost V1",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "shielded_joint",
+    "name": "Shielded Joint",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shielding_plate",
+    "name": "Shielding Plate",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shielding_shard",
+    "name": "Shielding Shard",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shielding_sheet",
+    "name": "Shielding Sheet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shimmering_lashtail",
+    "name": "Shimmering Lashtail",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "ship_sale_poster",
+    "name": "Ship Sale Poster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "short_alloy_wall_a",
+    "name": "Short Alloy Wall A",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "short_alloy_wall_b",
+    "name": "Short Alloy Wall B",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "short_circuit",
+    "name": "Short Circuit",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "short_concrete_wall",
+    "name": "Short Concrete Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "short_metal_wall",
+    "name": "Short Metal Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "short_stone_wall_a",
+    "name": "Short Stone Wall A",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "short_stone_wall_b",
+    "name": "Short Stone Wall B",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "short_timber_wall_a",
+    "name": "Short Timber Wall A",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "short_timber_wall_b",
+    "name": "Short Timber Wall B",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "short_wooden_wall",
+    "name": "Short Wooden Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "short_range_teleporter",
+    "name": "Short-Range Teleporter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shortburst_adaptor",
+    "name": "Shortburst Adaptor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "shovel",
+    "name": "Shovel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shrieking_oyster",
+    "name": "Shrieking Oyster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "shrieking_venttail",
+    "name": "Shrieking Venttail",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "side_panel",
+    "name": "Side Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "side_lit_flat_alloy_roof",
+    "name": "Side-Lit Flat Alloy Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sievert_beans",
+    "name": "Sievert Beans",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "signal_booster",
+    "name": "Signal Booster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "silicate_crab",
+    "name": "Silicate Crab",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "silicate_powder",
+    "name": "Silicate Powder",
+    "group": "resource",
+    "value": 2
+  },
+  {
+    "id": "silicon",
+    "name": "Silicon",
+    "group": "resource",
+    "value": 0
+  },
+  {
+    "id": "silicon_egg",
+    "name": "Silicon Egg",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "silver",
+    "name": "Silver",
+    "group": "resource",
+    "value": 186
+  },
+  {
+    "id": "silver_astronaut_statue",
+    "name": "Silver Astronaut Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "silver_atlas_statue",
+    "name": "Silver Atlas Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "silver_blob_statue",
+    "name": "Silver Blob Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "silver_diplo_statue",
+    "name": "Silver Diplo Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "silver_fighter_statue",
+    "name": "Silver Fighter Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "silver_gek_statue",
+    "name": "Silver Gek Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "silver_walker_statue",
+    "name": "Silver Walker Statue",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "simple_biscuit",
+    "name": "Simple Biscuit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "simple_desk",
+    "name": "Simple Desk",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "simple_translator",
+    "name": "Simple Translator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "singing_sea_snail",
+    "name": "Singing Sea-Snail",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "singular_angle_xvii",
+    "name": "Singular Angle XVII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "singularity_core",
+    "name": "Singularity Core",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "singularity_cortex",
+    "name": "Singularity Cortex",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "singularity_engine",
+    "name": "Singularity Engine",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "skylight_alloy_roof",
+    "name": "Skylight Alloy Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "slime_pop",
+    "name": "Slime Pop",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sloping_alloy_panel",
+    "name": "Sloping Alloy Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sloping_alloy_roof_gable",
+    "name": "Sloping Alloy Roof Gable",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sloping_alloy_roof_panel",
+    "name": "Sloping Alloy Roof Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sloping_concrete_panel",
+    "name": "Sloping Concrete Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sloping_metal_panel",
+    "name": "Sloping Metal Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sloping_stone_panel",
+    "name": "Sloping Stone Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sloping_stone_roof_gable",
+    "name": "Sloping Stone Roof Gable",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sloping_stone_roof_panel",
+    "name": "Sloping Stone Roof Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sloping_timber_panel",
+    "name": "Sloping Timber Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sloping_timber_roof_gable",
+    "name": "Sloping Timber Roof Gable",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sloping_timber_roof_panel",
+    "name": "Sloping Timber Roof Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sloping_wood_panel",
+    "name": "Sloping Wood Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_alloy_panel",
+    "name": "Small Alloy Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_alloy_triangle",
+    "name": "Small Alloy Triangle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_alloy_wall_a",
+    "name": "Small Alloy Wall A",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_alloy_wall_b",
+    "name": "Small Alloy Wall B",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_aquarium",
+    "name": "Small Aquarium",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_box",
+    "name": "Small Box",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_concrete_panel",
+    "name": "Small Concrete Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_concrete_triangle",
+    "name": "Small Concrete Triangle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_concrete_wall",
+    "name": "Small Concrete Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_crate",
+    "name": "Small Crate",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_furnace",
+    "name": "Small Furnace",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_generator",
+    "name": "Small Generator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_metal_panel",
+    "name": "Small Metal Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_metal_triangle",
+    "name": "Small Metal Triangle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_metal_wall",
+    "name": "Small Metal Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_paving",
+    "name": "Small Paving",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_stone_panel",
+    "name": "Small Stone Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_stone_triangle",
+    "name": "Small Stone Triangle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_stone_wall_a",
+    "name": "Small Stone Wall A",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_stone_wall_b",
+    "name": "Small Stone Wall B",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_timber_panel",
+    "name": "Small Timber Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_timber_triangle",
+    "name": "Small Timber Triangle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_timber_wall_a",
+    "name": "Small Timber Wall A",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_timber_wall_b",
+    "name": "Small Timber Wall B",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_vent",
+    "name": "Small Vent",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_wedge",
+    "name": "Small Wedge",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_window",
+    "name": "Small Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_wood_panel",
+    "name": "Small Wood Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_wooden_triangle",
+    "name": "Small Wooden Triangle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "small_wooden_wall",
+    "name": "Small Wooden Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "smoked_fish",
+    "name": "Smoked Fish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "smoked_meat",
+    "name": "Smoked Meat",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "smokey_meat_pie",
+    "name": "Smokey Meat Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sodium",
+    "name": "Sodium",
+    "group": "resource",
+    "value": 41
+  },
+  {
+    "id": "sodium_diode",
+    "name": "Sodium Diode",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sodium_nitrate",
+    "name": "Sodium Nitrate",
+    "group": "resource",
+    "value": 82
+  },
+  {
+    "id": "sofa",
+    "name": "Sofa",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "soft_and_spiky_surprise",
+    "name": "Soft and Spiky Surprise",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "soft_custard_fancy",
+    "name": "Soft Custard Fancy",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "softened_marrow",
+    "name": "Softened Marrow",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "soiled_soup",
+    "name": "Soiled Soup",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "solanium",
+    "name": "Solanium",
+    "group": "resource",
+    "value": 70
+  },
+  {
+    "id": "solar_mirror",
+    "name": "Solar Mirror",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "solar_panel",
+    "name": "Solar Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "solar_ray",
+    "name": "Solar Ray",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "solar_roach",
+    "name": "Solar Roach",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "solar_vine",
+    "name": "Solar Vine",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "solartillo",
+    "name": "Solartillo",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "solenoid",
+    "name": "Solenoid",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "solenoid_frigate",
+    "name": "Solenoid (Frigate)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "solid_cube",
+    "name": "Solid Cube",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "solidified_grease_pie",
+    "name": "Solidified Grease Pie",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "somnal_dust",
+    "name": "Somnal Dust",
+    "group": "resource",
+    "value": 1616
+  },
+  {
+    "id": "soul_chamber",
+    "name": "Soul Chamber",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "soul_engine",
+    "name": "Soul Engine",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spark_canister",
+    "name": "Spark Canister",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spark_plug",
+    "name": "Spark Plug",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spawning_sac",
+    "name": "Spawning Sac",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "speedbird_cowling",
+    "name": "Speedbird Cowling",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "speedbird_diffuser",
+    "name": "Speedbird Diffuser",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "speedbird_dome_section",
+    "name": "Speedbird Dome Section",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "speedbird_fairing",
+    "name": "Speedbird Fairing",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "speedbird_nacelle",
+    "name": "Speedbird Nacelle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spewing_vents",
+    "name": "Spewing Vents",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "sphere",
+    "name": "Sphere",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sphere_creator",
+    "name": "Sphere Creator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spiced_apple_cake",
+    "name": "Spiced 'Apple' Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spiced_ice",
+    "name": "Spiced Ice",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spicy_chum",
+    "name": "Spicy Chum",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spicy_fleshballs",
+    "name": "Spicy Fleshballs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spikey_tart",
+    "name": "Spikey Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spindle_tree",
+    "name": "Spindle Tree",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spiny_starfish",
+    "name": "Spiny Starfish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "splayed_hanging_lamp",
+    "name": "Splayed hanging Lamp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "splicers_delight",
+    "name": "Splicer's Delight",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sponge_of_ambrosia",
+    "name": "Sponge of Ambrosia",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spool_of_nano_cables",
+    "name": "Spool of Nano-Cables",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spore_dunkers",
+    "name": "Spore Dunkers",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "spotted_protofin",
+    "name": "Spotted Protofin",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "spring_casing",
+    "name": "Spring Casing",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "spurushko_mark_iv",
+    "name": "Spurushko Mark IV",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "sputtering_starship_trail",
+    "name": "Sputtering Starship Trail",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "square_deepwater_chamber",
+    "name": "Square Deepwater Chamber",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "square_room",
+    "name": "Square Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "squared_standing_light",
+    "name": "Squared Standing Light",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "squirming_fancy",
+    "name": "Squirming Fancy",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stable_iguenowah_ropes",
+    "name": "Stable Iguenowah-Ropes",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "stable_retort_xii",
+    "name": "Stable Retort XII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "stamina_enhancement_sigma",
+    "name": "Stamina Enhancement Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "stamina_enhancement_tau",
+    "name": "Stamina Enhancement Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "stamina_enhancement_theta",
+    "name": "Stamina Enhancement Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "standing_planter",
+    "name": "Standing Planter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "star_bramble",
+    "name": "Star Bramble",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "star_bulb",
+    "name": "Star Bulb",
+    "group": "resource",
+    "value": 32
+  },
+  {
+    "id": "star_seed",
+    "name": "Star Seed",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "star_silk",
+    "name": "Star Silk",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "starbirth_delight",
+    "name": "Starbirth Delight",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "starpollen_surprise",
+    "name": "Starpollen Surprise",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "starshell_crab",
+    "name": "Starshell Crab",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "starshield_battery",
+    "name": "Starshield Battery",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "starship_ai_valves",
+    "name": "Starship AI Valves",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "starship_launch_fuel",
+    "name": "Starship Launch Fuel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "startling_fancy",
+    "name": "Startling Fancy",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stasis_device",
+    "name": "Stasis Device",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "state_phasure",
+    "name": "State Phasure",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "station_override",
+    "name": "Station Override",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "steady_udyonkin_enti",
+    "name": "Steady Udyonkin-Enti",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "stealth_starship_trail",
+    "name": "Stealth Starship Trail",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "steamed_rubber",
+    "name": "Steamed Rubber",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "steamed_vegetables",
+    "name": "Steamed Vegetables",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stellar_custard",
+    "name": "Stellar Custard",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stellar_custard_tart",
+    "name": "Stellar Custard Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stellar_extractor_room",
+    "name": "Stellar Extractor Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stellar_ice_cream",
+    "name": "Stellar Ice Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stepladder",
+    "name": "Stepladder",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stewed_organs",
+    "name": "Stewed Organs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sticky_honey",
+    "name": "Sticky 'Honey'",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sticky_finger",
+    "name": "Sticky Finger",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stirring_void_egg",
+    "name": "Stirring Void Egg",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stolen_dna_samples",
+    "name": "Stolen DNA Samples",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_arch",
+    "name": "Stone Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_arch_door",
+    "name": "Stone Arch Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_dome_roof",
+    "name": "Stone Dome Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_doorway",
+    "name": "Stone Doorway",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_floor_grille",
+    "name": "Stone Floor Grille",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_floor_panel",
+    "name": "Stone Floor Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_frontage",
+    "name": "Stone Frontage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_grille_window",
+    "name": "Stone Grille Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_half_arch",
+    "name": "Stone Half Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_half_ramp",
+    "name": "Stone Half Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_half_ramp_platform",
+    "name": "Stone Half Ramp Platform",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_inner_roof_corner",
+    "name": "Stone Inner Roof Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_large_window",
+    "name": "Stone Large Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_power_door",
+    "name": "Stone Power Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_ramp",
+    "name": "Stone Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_rectangular_door",
+    "name": "Stone Rectangular Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_roof_cap",
+    "name": "Stone Roof Cap",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_roof_corner",
+    "name": "Stone Roof Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_roof_gable",
+    "name": "Stone Roof Gable",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_roof_panel",
+    "name": "Stone Roof Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_slit_window",
+    "name": "Stone Slit Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_support_pillar",
+    "name": "Stone Support Pillar",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_triangle",
+    "name": "Stone Triangle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_trough",
+    "name": "Stone Trough",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stone_wall",
+    "name": "Stone Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "stonescale_shark",
+    "name": "Stonescale Shark",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "storage_augmentation",
+    "name": "Storage Augmentation",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "storage_container",
+    "name": "Storage Container",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "storage_container_yellow",
+    "name": "Storage Container - Yellow",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "storage_panel",
+    "name": "Storage Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "storage_room",
+    "name": "Storage Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "storage_unit",
+    "name": "Storage Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "storm_crystal",
+    "name": "Storm Crystal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "straight_corridor",
+    "name": "Straight Corridor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "strange_gift_iv",
+    "name": "Strange Gift IV",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "strange_insight_viii",
+    "name": "Strange Insight VIII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "streamlined_trim",
+    "name": "Streamlined Trim",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "streamlined_trim_cap",
+    "name": "Streamlined Trim Cap",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "strider_sausage",
+    "name": "Strider Sausage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sub_light_amplifier",
+    "name": "Sub-Light Amplifier",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "subatomic_regulators",
+    "name": "Subatomic Regulators",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "subdued_concept_ix",
+    "name": "Subdued Concept IX",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "sublime_gleam_iii",
+    "name": "Sublime Gleam III",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "sublime_riposte_vi",
+    "name": "Sublime Riposte VI",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "submerged_relic",
+    "name": "Submerged Relic",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "subterranean_relic",
+    "name": "Subterranean Relic",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "succulent_tree",
+    "name": "Succulent Tree",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "suchinohe_mark_x",
+    "name": "Suchinohe Mark X",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "sugar_dough",
+    "name": "Sugar Dough",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sukaiwak_exceptional",
+    "name": "Sukaiwak Exceptional",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "sulfur",
+    "name": "Sulfur",
+    "group": "resource",
+    "value": 0
+  },
+  {
+    "id": "sulphurfish",
+    "name": "Sulphurfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "sulphurine",
+    "name": "Sulphurine",
+    "group": "resource",
+    "value": 20
+  },
+  {
+    "id": "sunspine_basker",
+    "name": "Sunspine Basker",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "sunspot_eel",
+    "name": "Sunspot Eel",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "superconducting_fibre",
+    "name": "Superconducting Fibre",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "superconductive_lock",
+    "name": "Superconductive Lock",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "superconductor",
+    "name": "Superconductor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "supercruise_aerofoil",
+    "name": "Supercruise Aerofoil",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "supercruise_cowling",
+    "name": "Supercruise Cowling",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "superior_translator",
+    "name": "Superior Translator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "superoxide_crystal",
+    "name": "Superoxide Crystal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "supply_depot",
+    "name": "Supply Depot",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "supply_pipe",
+    "name": "Supply Pipe",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "survey_device",
+    "name": "Survey Device",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "suspension_fluid",
+    "name": "Suspension Fluid",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "suspicious_module",
+    "name": "Suspicious Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "suspicious_packet_arms",
+    "name": "Suspicious Packet (Arms)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "suspicious_packet_goods",
+    "name": "Suspicious Packet (Goods)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "suspicious_packet_tech",
+    "name": "Suspicious Packet (Tech)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sweeperfish",
+    "name": "Sweeperfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "sweet_and_salty_puff",
+    "name": "Sweet and Salty Puff",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sweet_cream_dreams",
+    "name": "Sweet Cream Dreams",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sweetened_butter",
+    "name": "Sweetened Butter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sweetened_compost",
+    "name": "Sweetened Compost",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sweetened_mucous",
+    "name": "Sweetened Mucous",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sweetened_proto_butter",
+    "name": "Sweetened Proto-Butter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sweetroot",
+    "name": "Sweetroot",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "sweetwater_minnow",
+    "name": "Sweetwater Minnow",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "swept_casing",
+    "name": "Swept Casing",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "swept_sofa",
+    "name": "Swept Sofa",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "swift_leg_bones",
+    "name": "Swift Leg Bones",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "synthetic_honey",
+    "name": "Synthetic Honey",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "synthetic_worms",
+    "name": "Synthetic Worms",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "syrup_drenched_delight",
+    "name": "Syrup-Drenched Delight",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "syrupy_batter",
+    "name": "Syrupy Batter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "syrupy_caramel_slice",
+    "name": "Syrupy Caramel Slice",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "syrupy_nectar",
+    "name": "Syrupy Nectar",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "syrupy_proto_butter",
+    "name": "Syrupy Proto-Butter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "syrupy_tingler",
+    "name": "Syrupy Tingler",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "syrupy_viscera",
+    "name": "Syrupy Viscera",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "t_shaped_corridor",
+    "name": "T-Shaped Corridor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "t_shaped_glass_tunnel",
+    "name": "T-Shaped Glass Tunnel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "table_lamp",
+    "name": "Table Lamp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tainted_metal",
+    "name": "Tainted Metal",
+    "group": "resource",
+    "value": 380
+  },
+  {
+    "id": "tall_antenna",
+    "name": "Tall Antenna",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tall_bucket",
+    "name": "Tall Bucket",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tall_cabinet",
+    "name": "Tall Cabinet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tall_eggs",
+    "name": "Tall Eggs",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tall_flat_alloy_roof",
+    "name": "Tall Flat Alloy Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tall_moulded_lockbox",
+    "name": "Tall Moulded Lockbox",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tamper_prevention_device",
+    "name": "Tamper Prevention Device",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "tangleweed",
+    "name": "Tangleweed",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tangy_cheese",
+    "name": "Tangy Cheese",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tangy_organ_surprise",
+    "name": "Tangy Organ Surprise",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tangy_vegetable_stew",
+    "name": "Tangy Vegetable Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tank_of_coolant",
+    "name": "Tank of Coolant",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tech_panel",
+    "name": "Tech Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "technology_room_expansion",
+    "name": "Technology Room (Expansion)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "teleport_cable",
+    "name": "Teleport Cable",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "teleport_chamber",
+    "name": "Teleport Chamber",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "teleport_coordinators",
+    "name": "Teleport Coordinators",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "teleport_receiver",
+    "name": "Teleport Receiver",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "teleportation_terminal",
+    "name": "Teleportation Terminal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "temporal_warp_computer",
+    "name": "Temporal Warp Computer",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "tentacle_spire",
+    "name": "Tentacle Spire",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tentacled_banner",
+    "name": "Tentacled Banner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tentacled_decal",
+    "name": "Tentacled Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "terbium_growth",
+    "name": "Terbium Growth",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "terrain_manipulator",
+    "name": "Terrain Manipulator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "terrarium",
+    "name": "Terrarium",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "terrifying_sample",
+    "name": "Terrifying Sample",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "terumin",
+    "name": "Terumin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tethys_beam",
+    "name": "Tethys Beam",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "tetmalont_mark_vi",
+    "name": "Tetmalont Mark VI",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "tetracobalt",
+    "name": "TetraCobalt",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thamium9",
+    "name": "Thamium9",
+    "group": "resource",
+    "value": 21
+  },
+  {
+    "id": "thawed_diamondfin",
+    "name": "Thawed Diamondfin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "the_acmiinar_b600",
+    "name": "The Acmiinar B600",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_angler",
+    "name": "The Angler",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "the_auristinc_taed_k200",
+    "name": "The Auristinc-Taed K200",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_ayborodu_v0_28",
+    "name": "The Ayborodu V0.28",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_bawilotag_v5_30",
+    "name": "The Bawilotag v5.30",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_bujunman_x400",
+    "name": "The Bujunman X400",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_giumelbu_baxa_v4_10",
+    "name": "The Giumelbu Baxa v4.10",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_guchihama_v8_17",
+    "name": "The Guchihama v8.17",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_hefeichac_duan_u200",
+    "name": "The Hefeichac Duan U200",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_hughnava_b300",
+    "name": "The Hughnava B300",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_ijonanko_uiet_u100",
+    "name": "The Ijonanko-Uiet U100",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_isrankan_v6_11",
+    "name": "The Isrankan v6.11",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_issinggas_coyli_j600",
+    "name": "The Issinggas Coyli J600",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_lunker",
+    "name": "The Lunker",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "the_mepushpoo_v5_4",
+    "name": "The Mepushpoo v5.4",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_natlinmi_inzu_y200",
+    "name": "The Natlinmi Inzu Y200",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_ouwerkpa_n300",
+    "name": "The Ouwerkpa N300",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_pie_of_knowledge",
+    "name": "The Pie Of Knowledge",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "the_ripugand_t600",
+    "name": "The Ripugand T600",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_rulsefren_terq_d600",
+    "name": "The Rulsefren-Terq D600",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_runinsko_v1_12",
+    "name": "The Runinsko v1.12",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_selmikka_tosu_v6_28",
+    "name": "The Selmikka-Tosu v6.28",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_spawning_tart",
+    "name": "The Spawning Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "the_stellarator",
+    "name": "The Stellarator",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "the_t400",
+    "name": "The T400",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_teskaurvoy_b700",
+    "name": "The Teskaurvoy B700",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_toothbreaker",
+    "name": "The Toothbreaker",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "the_totzerid_t600",
+    "name": "The Totzerid T600",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_utyannwin_v6_7",
+    "name": "The Utyannwin v6.7",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "the_worst_stew",
+    "name": "The Worst Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "theory_of_ivkativa",
+    "name": "Theory of Ivkativa",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "theory_of_yoncoraba_aodi",
+    "name": "Theory of Yoncoraba Aodi",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thermal_buffer",
+    "name": "Thermal Buffer",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thermal_grille",
+    "name": "Thermal Grille",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thermal_panels",
+    "name": "Thermal Panels",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thermal_protection_module_cold",
+    "name": "Thermal Protection Module (Cold)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thermal_protection_module_heat",
+    "name": "Thermal Protection Module (Heat)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thermal_protection_upgrade_cold",
+    "name": "Thermal Protection Upgrade (Cold)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thermal_protection_upgrade_heat",
+    "name": "Thermal Protection Upgrade (Heat)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thermic_condensate",
+    "name": "Thermic Condensate",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thermic_layer",
+    "name": "Thermic Layer",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thermic_layer_next",
+    "name": "Thermic Layer (NEXT)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thermic_layer_sigma",
+    "name": "Thermic Layer Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thermic_layer_tau",
+    "name": "Thermic Layer Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thermic_layer_theta",
+    "name": "Thermic Layer Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thermoregulator",
+    "name": "Thermoregulator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thermoregulator_frigate",
+    "name": "Thermoregulator (Frigate)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "thick_meat_stew",
+    "name": "Thick Meat Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thick_sweet_batter",
+    "name": "Thick, Sweet Batter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thin_alloy_wall",
+    "name": "Thin Alloy Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thin_concrete_wall",
+    "name": "Thin Concrete Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thin_metal_wall",
+    "name": "Thin Metal Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thin_stone_wall",
+    "name": "Thin Stone Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thin_timber_wall",
+    "name": "Thin Timber Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thin_wooden_wall",
+    "name": "Thin Wooden Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thunderbird_heavy_booster",
+    "name": "Thunderbird Heavy Booster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thunderbird_landing_thrusters",
+    "name": "Thunderbird Landing Thrusters",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thunderbird_class_cockpit",
+    "name": "Thunderbird-Class Cockpit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thunderbird_class_hab",
+    "name": "Thunderbird-Class Hab",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thunderbird_class_landing_bay",
+    "name": "Thunderbird-Class Landing Bay",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thunderbird_class_walkway",
+    "name": "Thunderbird-Class Walkway",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "thunderfin",
+    "name": "Thunderfin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ticket_to_freedom",
+    "name": "Ticket to Freedom",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tied_drapes",
+    "name": "Tied Drapes",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_angled_door",
+    "name": "Timber Angled Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_arch",
+    "name": "Timber Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_doorway",
+    "name": "Timber Doorway",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_floor_panel",
+    "name": "Timber Floor Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_frontage",
+    "name": "Timber Frontage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_half_arch",
+    "name": "Timber Half Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_half_ramp",
+    "name": "Timber Half Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_half_ramp_platform",
+    "name": "Timber Half Ramp Platform",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_inner_roof_corner",
+    "name": "Timber Inner Roof Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_power_door",
+    "name": "Timber Power Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_ramp",
+    "name": "Timber Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_rectangular_door",
+    "name": "Timber Rectangular Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_roof_cap",
+    "name": "Timber Roof Cap",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_roof_corner",
+    "name": "Timber Roof Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_roof_gable",
+    "name": "Timber Roof Gable",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_roof_panel",
+    "name": "Timber Roof Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_shelving_unit",
+    "name": "Timber Shelving Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_triangle",
+    "name": "Timber Triangle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_wall",
+    "name": "Timber Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "timber_framed_glass_panel",
+    "name": "Timber-Framed Glass Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tiny_motor",
+    "name": "Tiny Motor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "tiny_motor_frigate",
+    "name": "Tiny Motor (Frigate)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "tiny_scuttlefish",
+    "name": "Tiny Scuttlefish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "titan_heavy_booster",
+    "name": "Titan Heavy Booster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "titan_sublight_thruster",
+    "name": "Titan Sublight Thruster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "titan_wing_module",
+    "name": "Titan Wing Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "titan_class_cockpit",
+    "name": "Titan-Class Cockpit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "titan_class_hab",
+    "name": "Titan-Class Hab",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "titan_class_landing_bay",
+    "name": "Titan-Class Landing Bay",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "titan_class_walkway",
+    "name": "Titan-Class Walkway",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "titanium",
+    "name": "Titanium",
+    "group": "resource",
+    "value": 61.9
+  },
+  {
+    "id": "tooth_pickers",
+    "name": "Tooth Pickers",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "top_lit_flat_alloy_roof",
+    "name": "Top-lit Flat Alloy Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "torpedo_launcher",
+    "name": "Torpedo Launcher",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tortured_honey_cake",
+    "name": "Tortured Honey Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "toxic_jelly",
+    "name": "Toxic Jelly",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "toxic_protection_module",
+    "name": "Toxic Protection Module",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "toxic_protection_upgrade",
+    "name": "Toxic Protection Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "toxic_stonefish",
+    "name": "Toxic Stonefish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "toxin_suppressor",
+    "name": "Toxin Suppressor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "toxin_suppressor_next",
+    "name": "Toxin Suppressor (NEXT)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "toxin_suppressor_sigma",
+    "name": "Toxin Suppressor Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "toxin_suppressor_tau",
+    "name": "Toxin Suppressor Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "toxin_suppressor_theta",
+    "name": "Toxin Suppressor Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "trade_rocket",
+    "name": "Trade Rocket",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "traditional_cake",
+    "name": "Traditional Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "translucent_gulper",
+    "name": "Translucent Gulper",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "transmission_box",
+    "name": "Transmission Box",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "transmission_box_frigate",
+    "name": "Transmission Box (Frigate)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "trident_key",
+    "name": "Trident Key",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "trident_key_damaged_component",
+    "name": "Trident Key (Damaged Component)",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "triple_burst_firework",
+    "name": "Triple Burst Firework",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "triple_hanging_lamp",
+    "name": "Triple Hanging Lamp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tritium",
+    "name": "Tritium",
+    "group": "resource",
+    "value": 6
+  },
+  {
+    "id": "tritium_hypercluster",
+    "name": "Tritium Hypercluster",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "tropheum",
+    "name": "Tropheum",
+    "group": "resource",
+    "value": 137.5
+  },
+  {
+    "id": "tube_light",
+    "name": "Tube Light",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "turbine_aerofoil",
+    "name": "Turbine Aerofoil",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "turbine_cowling",
+    "name": "Turbine Cowling",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "twilight_cavefish",
+    "name": "Twilight Cavefish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "twin_alloy_window",
+    "name": "Twin Alloy Window",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "twin_dynamo_jets",
+    "name": "Twin Dynamo Jets",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "twin_echo_jets",
+    "name": "Twin Echo Jets",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "twin_flag_divider",
+    "name": "Twin Flag Divider",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "twin_timber_windows",
+    "name": "Twin Timber Windows",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "twisted_gulper",
+    "name": "Twisted Gulper",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "u_skylight_timber_trapezoid_roof",
+    "name": "U-Skylight Timber Trapezoid Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ubeijiao_mark_v",
+    "name": "Ubeijiao Mark V",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "uitaakis_mark_ix",
+    "name": "Uitaakis Mark IX",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "umbrella_tree",
+    "name": "Umbrella Tree",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ummerukam_mark_xviii",
+    "name": "Ummerukam Mark XVIII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "unbound_cream_horn",
+    "name": "Unbound Cream Horn",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "unbound_monstrosity",
+    "name": "Unbound Monstrosity",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "underwater_oxygen_upgrade",
+    "name": "Underwater Oxygen Upgrade",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "underwater_protection_module",
+    "name": "Underwater Protection Module",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "unearthed_treasure",
+    "name": "Unearthed Treasure",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "united_federation_of_travelers_banner",
+    "name": "United Federation of Travelers Banner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "united_federation_of_travelers_decal",
+    "name": "United Federation of Travelers Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "unrefined_pyrite_grease",
+    "name": "Unrefined Pyrite Grease",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "unsolvable_jam_turnover",
+    "name": "Unsolvable Jam Turnover",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "unstable_gel",
+    "name": "Unstable Gel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "unstable_plasma",
+    "name": "Unstable Plasma",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "unusual_ovetskaye_vexi",
+    "name": "Unusual Ovetskaye-Vexi",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "upgrade_module",
+    "name": "Upgrade Module",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "upholstered_chair",
+    "name": "Upholstered Chair",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "uranium",
+    "name": "Uranium",
+    "group": "resource",
+    "value": 62
+  },
+  {
+    "id": "urbashyo_laeu_mark_xi",
+    "name": "Urbashyo-Laeu Mark XI",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "urihonma_mark_ii",
+    "name": "Urihonma Mark II",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "utopia_research_station",
+    "name": "Utopia Research Station",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "v_13q_vivid_theory",
+    "name": "V/13Q Vivid Theory",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "vampire_squid",
+    "name": "Vampire Squid",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vector_compressors",
+    "name": "Vector Compressors",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vectorfin",
+    "name": "Vectorfin",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "venemous_triggerfin",
+    "name": "Venemous Triggerfin",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "venom_urchin",
+    "name": "Venom Urchin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "venomous_triggerfin",
+    "name": "Venomous Triggerfin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "venomtooth_wriggler",
+    "name": "Venomtooth Wriggler",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "ventilated_crate",
+    "name": "Ventilated Crate",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "ventilated_flat_stone_roof",
+    "name": "Ventilated Flat Stone Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vertical_glass_tunnel",
+    "name": "Vertical Glass Tunnel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "very_thick_custard",
+    "name": "Very Thick Custard",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vesper_cowling",
+    "name": "Vesper Cowling",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vesper_diffuser",
+    "name": "Vesper Diffuser",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vesper_diffuser_hull_plating",
+    "name": "Vesper Diffuser (Hull Plating)",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vesper_sail",
+    "name": "Vesper Sail",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "viewing_sphere",
+    "name": "Viewing Sphere",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vigilant_stone",
+    "name": "Vigilant Stone",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vigilant_taro",
+    "name": "Vigilant Taro",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vile_cortex",
+    "name": "Vile cortex",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vile_spawn",
+    "name": "Vile Spawn",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vintage_cooking_pan",
+    "name": "Vintage Cooking Pan",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vintage_dish",
+    "name": "Vintage Dish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vintage_tap",
+    "name": "Vintage Tap",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vintage_teapot",
+    "name": "Vintage Teapot",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vintage_tumbler",
+    "name": "Vintage Tumbler",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "viper_eel",
+    "name": "Viper Eel",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "viridium",
+    "name": "Viridium",
+    "group": "resource",
+    "value": 303
+  },
+  {
+    "id": "viscous_custard",
+    "name": "Viscous Custard",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "viscous_fluids",
+    "name": "Viscous Fluids",
+    "group": "resource",
+    "value": 20
+  },
+  {
+    "id": "vivid_lusonhistr",
+    "name": "Vivid Lusonhistr",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "void_egg",
+    "name": "Void Egg",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "void_husk",
+    "name": "Void Husk",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "void_mote",
+    "name": "Void Mote",
+    "group": "resource",
+    "value": 380
+  },
+  {
+    "id": "void_squid",
+    "name": "Void Squid",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "volatile_chocolate_fancy",
+    "name": "Volatile Chocolate Fancy",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "voltaic_amplifier",
+    "name": "Voltaic Amplifier",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "voltaic_cell",
+    "name": "Voltaic Cell",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vortex_cube",
+    "name": "Vortex Cube",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vy",
+    "name": "Vy",
+    "group": "resource",
+    "value": 0
+  },
+  {
+    "id": "vyice_cream",
+    "name": "Vy'ice Cream",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vykeen_dagger",
+    "name": "Vy'keen Dagger",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vykeen_decal",
+    "name": "Vy'keen Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vykeen_effigy",
+    "name": "Vy'keen Effigy",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "vykeen_tablet",
+    "name": "Vy'keen Tablet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "w_q_obscured_angle",
+    "name": "W-Q Obscured Angle",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "wailing_batter",
+    "name": "Wailing Batter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wailing_caramel_cake",
+    "name": "Wailing Caramel Cake",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "walker_brain",
+    "name": "Walker Brain",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wall_fan",
+    "name": "Wall Fan",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wall_flag_1",
+    "name": "Wall Flag 1",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wall_flag_2",
+    "name": "Wall Flag 2",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wall_flag_3",
+    "name": "Wall Flag 3",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wall_light",
+    "name": "Wall Light",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wall_screen",
+    "name": "Wall Screen",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wall_switch",
+    "name": "Wall Switch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wall_unit",
+    "name": "Wall Unit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wandering_kelpfin",
+    "name": "Wandering Kelpfin",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "warden_eel",
+    "name": "Warden Eel",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "warm_proto_milk",
+    "name": "Warm Proto-Milk",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "warning_decal",
+    "name": "Warning Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "warp_cell",
+    "name": "Warp Cell",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "warp_core_resonator",
+    "name": "Warp Core Resonator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "warp_hypercore",
+    "name": "Warp Hypercore",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "warp_reactor_sigma",
+    "name": "Warp Reactor Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "warp_reactor_tau",
+    "name": "Warp Reactor Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "warp_reactor_theta",
+    "name": "Warp Reactor Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "warp_shielding_sigma",
+    "name": "Warp Shielding Sigma",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "warp_shielding_tau",
+    "name": "Warp Shielding Tau",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "warp_shielding_theta",
+    "name": "Warp Shielding Theta",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "warty_frogfish",
+    "name": "Warty Frogfish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wash_trough",
+    "name": "Wash Trough",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "waspfish",
+    "name": "Waspfish",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "watchful_protrusion",
+    "name": "Watchful Protrusion",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "water_tower",
+    "name": "Water Tower",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "watertight_door",
+    "name": "Watertight Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "waveform_engine",
+    "name": "Waveform Engine",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "waveform_oscillator",
+    "name": "Waveform Oscillator",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "waveform_recycler",
+    "name": "Waveform Recycler",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "weapon_rack",
+    "name": "Weapon Rack",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "weapons_terminal",
+    "name": "Weapons Terminal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "weapons_terminal_room",
+    "name": "Weapons Terminal Room",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "weathered_hanging",
+    "name": "Weathered Hanging",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "weathered_hanging_triptych",
+    "name": "Weathered Hanging Triptych",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "weatherproof_rubber",
+    "name": "Weatherproof Rubber",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "welding_soap",
+    "name": "Welding Soap",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "well_smoked_biscuit",
+    "name": "Well-Smoked Biscuit",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "well_stirred_stew",
+    "name": "Well-Stirred Stew",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "weltscale_clam",
+    "name": "Weltscale Clam",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "whalesong_flute",
+    "name": "Whalesong Flute",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wheel_of_hirk_firework",
+    "name": "Wheel of Hirk Firework",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wheelbarrow",
+    "name": "Wheelbarrow",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "whispering_bonefish",
+    "name": "Whispering Bonefish",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "whispering_omelette",
+    "name": "Whispering Omelette",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "white_border_decal",
+    "name": "White Border Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "white_design_decal",
+    "name": "White Design Decal",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "whitebait",
+    "name": "Whitebait",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "widebeam_adaptor",
+    "name": "Widebeam Adaptor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "widebeam_adaptor_v1",
+    "name": "Widebeam Adaptor V1",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "wideshot_adaptor",
+    "name": "Wideshot Adaptor",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "wild_milk",
+    "name": "Wild Milk",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wild_yeast",
+    "name": "Wild Yeast",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wiring_loom",
+    "name": "Wiring Loom",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wispscale_darter",
+    "name": "Wispscale Darter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wizened_stump",
+    "name": "Wizened Stump",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wonder_projector",
+    "name": "Wonder Projector",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wood_floor_panel",
+    "name": "Wood Floor Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wood_framed_glass_panel",
+    "name": "Wood-Framed Glass Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_arch",
+    "name": "Wooden Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_door_frame",
+    "name": "Wooden Door Frame",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_doorway",
+    "name": "Wooden Doorway",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_frontage",
+    "name": "Wooden Frontage",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_half_arch",
+    "name": "Wooden Half Arch",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_half_ramp",
+    "name": "Wooden Half Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_inner_roof_corner",
+    "name": "Wooden Inner Roof Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_pallet",
+    "name": "Wooden Pallet",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_power_door",
+    "name": "Wooden Power Door",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_ramp",
+    "name": "Wooden Ramp",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_roof",
+    "name": "Wooden Roof",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_roof_corner",
+    "name": "Wooden Roof Corner",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_roof_panel",
+    "name": "Wooden Roof Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_triangle",
+    "name": "Wooden Triangle",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_wall",
+    "name": "Wooden Wall",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wooden_window_panel",
+    "name": "Wooden Window Panel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "worktop",
+    "name": "Worktop",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wormhole_brain",
+    "name": "Wormhole Brain",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "wormhole_brain_implant",
+    "name": "Wormhole Brain Implant",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "wormskin_folio",
+    "name": "Wormskin Folio",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wriggling_companion",
+    "name": "Wriggling Companion",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wriggling_doughnut",
+    "name": "Wriggling Doughnut",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wriggling_jam",
+    "name": "Wriggling Jam",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wriggling_tack",
+    "name": "Wriggling Tack",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "wriggling_tart",
+    "name": "Wriggling Tart",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "writhing_brainworm",
+    "name": "Writhing Brainworm",
+    "group": "unknown",
+    "value": 0
+  },
+  {
+    "id": "writhing_bush",
+    "name": "Writhing Bush",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "writhing_jam_puff",
+    "name": "Writhing Jam Puff",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "writhing_roiling_batter",
+    "name": "Writhing, Roiling Batter",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "x_shaped_corridor",
+    "name": "X-Shaped Corridor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "x_shaped_glass_tunnel",
+    "name": "X-Shaped Glass Tunnel",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "xeno_sponge",
+    "name": "Xeno-Sponge",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "yazzioss_mark_xvii",
+    "name": "Yazzioss Mark XVII",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "zenith_class_reactor",
+    "name": "Zenith-Class Reactor",
+    "group": "product",
+    "value": 0
+  },
+  {
+    "id": "zihurikha_mark_iv",
+    "name": "Zihurikha Mark IV",
+    "group": "technology",
+    "value": 0
+  },
+  {
+    "id": "zinc",
+    "name": "Zinc",
+    "group": "resource",
+    "value": 41.3
+  }
 ]

--- a/src/data/refiner.json
+++ b/src/data/refiner.json
@@ -1,43 +1,6837 @@
 [
   {
-    "id": "pure_ferrite_from_dust",
-    "name": "Pure Ferrite",
-    "inputs": [{"item": "ferrite_dust", "qty": 2}],
-    "output": {"item": "pure_ferrite", "qty": 1},
-    "timeSeconds": 30
-  },
-  {
-    "id": "magnetised_from_pure",
-    "name": "Magnetised Ferrite",
-    "inputs": [{"item": "pure_ferrite", "qty": 2}],
-    "output": {"item": "magnetised_ferrite", "qty": 1},
-    "timeSeconds": 45
-  },
-  {
-    "id": "condensed_from_carbon",
-    "name": "Condensed Carbon",
-    "inputs": [{"item": "carbon", "qty": 2}],
-    "output": {"item": "condensed_carbon", "qty": 1},
-    "timeSeconds": 30
-  },
-  {
-    "id": "chromatic_from_copper",
-    "name": "Chromatic Alloy",
+    "id": "loosen_bonds_methane_crystallised_helium_quartzite_0",
+    "name": "Loosen Bonds",
     "inputs": [
-      {"item": "condensed_carbon", "qty": 1},
-      {"item": "ionised_cobalt", "qty": 1}
+      {
+        "item": "methane",
+        "qty": 1
+      },
+      {
+        "item": "crystallised_helium",
+        "qty": 1
+      },
+      {
+        "item": "quartzite",
+        "qty": 1
+      }
     ],
-    "output": {"item": "chromatic_metal", "qty": 2},
+    "output": {
+      "item": "activated_quartzite",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "loosen_bonds_methane_lithium_quartzite_1",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "methane",
+        "qty": 1
+      },
+      {
+        "item": "lithium",
+        "qty": 1
+      },
+      {
+        "item": "quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "activated_quartzite",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_ferrite_dust_paraffinium_2",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "paraffinium",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "ammonia",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_pure_ferrite_paraffinium_3",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "paraffinium",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "ammonia",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "floral_titration_fungal_mould_salt_4",
+    "name": "Floral Titration",
+    "inputs": [
+      {
+        "item": "fungal_mould",
+        "qty": 2
+      },
+      {
+        "item": "salt",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ammonia",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_fusion_nitrogen_di_hydrogen_5",
+    "name": "Organic Fusion",
+    "inputs": [
+      {
+        "item": "nitrogen",
+        "qty": 1
+      },
+      {
+        "item": "di_hydrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ammonia",
+      "qty": 1
+    },
+    "timeSeconds": 10
+  },
+  {
+    "id": "alloy_latticing_paraffinium_gold_cobalt_6",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "paraffinium",
+        "qty": 30
+      },
+      {
+        "item": "gold",
+        "qty": 10
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "aronium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_paraffinium_gold_ionised_cobalt_7",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "paraffinium",
+        "qty": 30
+      },
+      {
+        "item": "gold",
+        "qty": 10
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "aronium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_paraffinium_platinum_cobalt_8",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "paraffinium",
+        "qty": 30
+      },
+      {
+        "item": "platinum",
+        "qty": 5
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "aronium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_paraffinium_platinum_ionised_cobalt_9",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "paraffinium",
+        "qty": 30
+      },
+      {
+        "item": "platinum",
+        "qty": 5
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "aronium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_paraffinium_silver_cobalt_10",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "paraffinium",
+        "qty": 30
+      },
+      {
+        "item": "silver",
+        "qty": 20
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "aronium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_paraffinium_silver_ionised_cobalt_11",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "paraffinium",
+        "qty": 30
+      },
+      {
+        "item": "silver",
+        "qty": 20
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "aronium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_paraffinium_tritium_cobalt_12",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "paraffinium",
+        "qty": 30
+      },
+      {
+        "item": "tritium",
+        "qty": 20
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "aronium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_paraffinium_tritium_ionised_cobalt_13",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "paraffinium",
+        "qty": 30
+      },
+      {
+        "item": "tritium",
+        "qty": 20
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "aronium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "volcanic_transmutation_pyrite_magnetised_ferrite_14",
+    "name": "Volcanic Transmutation",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 1
+      },
+      {
+        "item": "magnetised_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "basalt",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "volcanic_transmutation_phosphorus_magnetised_ferrite_15",
+    "name": "Volcanic Transmutation",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 1
+      },
+      {
+        "item": "magnetised_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "basalt",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "encourage_growth_pyrite_sulphurine_16",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 1
+      },
+      {
+        "item": "sulphurine",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cactus_flesh",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "encourage_growth_pyrite_oxygen_17",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 2
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cactus_flesh",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_pyrite_methane_18",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cactus_flesh",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_cactus_flesh_pyrite_19",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "cactus_flesh",
+        "qty": 1
+      },
+      {
+        "item": "pyrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cactus_flesh",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_expansion_cadmium_chromatic_metal_20",
+    "name": "Chromatic Expansion",
+    "inputs": [
+      {
+        "item": "cadmium",
+        "qty": 1
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cadmium",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "burn_plantlife_cactus_flesh_21",
+    "name": "Burn Plantlife",
+    "inputs": [
+      {
+        "item": "cactus_flesh",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "carbon",
+      "qty": 2
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "burn_plantlife_fungal_mould_22",
+    "name": "Burn Plantlife",
+    "inputs": [
+      {
+        "item": "fungal_mould",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "carbon",
+      "qty": 2
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "burn_plantlife_gamma_root_23",
+    "name": "Burn Plantlife",
+    "inputs": [
+      {
+        "item": "gamma_root",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "carbon",
+      "qty": 2
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "burn_plantlife_solanium_24",
+    "name": "Burn Plantlife",
+    "inputs": [
+      {
+        "item": "solanium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "carbon",
+      "qty": 2
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "burn_plantlife_star_bulb_25",
+    "name": "Burn Plantlife",
+    "inputs": [
+      {
+        "item": "star_bulb",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "carbon",
+      "qty": 2
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "inefficient_burn_oxygen_26",
+    "name": "Inefficient Burn",
+    "inputs": [
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "carbon",
+      "qty": 1
+    },
+    "timeSeconds": 5
+  },
+  {
+    "id": "release_carbon_condensed_carbon_27",
+    "name": "Release Carbon",
+    "inputs": [
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "carbon",
+      "qty": 2
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "bonded_chlorine_extraction_kelp_sac_oxygen_28",
+    "name": "Bonded Chlorine Extraction",
+    "inputs": [
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chlorine",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chlorine_expansion_chlorine_oxygen_29",
+    "name": "Chlorine Expansion",
+    "inputs": [
+      {
+        "item": "chlorine",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "chlorine",
+      "qty": 6
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "concentrate_salt_salt_30",
+    "name": "Concentrate Salt",
+    "inputs": [
+      {
+        "item": "salt",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "chlorine",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "dissolve_natural_salts_kelp_sac_chlorine_31",
+    "name": "Dissolve Natural Salts",
+    "inputs": [
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      },
+      {
+        "item": "chlorine",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chlorine",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "dissolve_natural_salts_kelp_sac_salt_32",
+    "name": "Dissolve Natural Salts",
+    "inputs": [
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      },
+      {
+        "item": "salt",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chlorine",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "efficient_salt_evaporation_salt_oxygen_33",
+    "name": "Efficient Salt Evaporation",
+    "inputs": [
+      {
+        "item": "salt",
+        "qty": 2
+      },
+      {
+        "item": "oxygen",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "chlorine",
+      "qty": 5
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "pugneum_washing_kelp_sac_pugneum_34",
+    "name": "Pugneum Washing",
+    "inputs": [
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      },
+      {
+        "item": "pugneum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chlorine",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_metal_fusion_pure_ferrite_copper_35",
+    "name": "Chromatic Metal Fusion",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "copper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_metal_fusion_pure_ferrite_activated_copper_36",
+    "name": "Chromatic Metal Fusion",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "activated_copper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_metal_fusion_pure_ferrite_cadmium_37",
+    "name": "Chromatic Metal Fusion",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "cadmium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_metal_fusion_pure_ferrite_emeril_38",
+    "name": "Chromatic Metal Fusion",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "emeril",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 3
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_metal_fusion_pure_ferrite_activated_cadmium_39",
+    "name": "Chromatic Metal Fusion",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "activated_cadmium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 4
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_metal_fusion_pure_ferrite_indium_40",
+    "name": "Chromatic Metal Fusion",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "indium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 4
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_metal_fusion_pure_ferrite_quartzite_41",
+    "name": "Chromatic Metal Fusion",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 4
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_metal_fusion_pure_ferrite_activated_emeril_42",
+    "name": "Chromatic Metal Fusion",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "activated_emeril",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 6
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_metal_fusion_pure_ferrite_activated_indium_43",
+    "name": "Chromatic Metal Fusion",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "activated_indium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 8
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_metal_fusion_pure_ferrite_activated_quartzite_44",
+    "name": "Chromatic Metal Fusion",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "activated_quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 8
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_stellar_fusion_gold_silver_cadmium_45",
+    "name": "Chromatic Stellar Fusion",
+    "inputs": [
+      {
+        "item": "gold",
+        "qty": 1
+      },
+      {
+        "item": "silver",
+        "qty": 1
+      },
+      {
+        "item": "cadmium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 10
+    },
+    "timeSeconds": 288
+  },
+  {
+    "id": "chromatic_stellar_fusion_gold_silver_emeril_46",
+    "name": "Chromatic Stellar Fusion",
+    "inputs": [
+      {
+        "item": "gold",
+        "qty": 1
+      },
+      {
+        "item": "silver",
+        "qty": 1
+      },
+      {
+        "item": "emeril",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 20
+    },
+    "timeSeconds": 288
+  },
+  {
+    "id": "chromatic_stellar_fusion_gold_silver_indium_47",
+    "name": "Chromatic Stellar Fusion",
+    "inputs": [
+      {
+        "item": "gold",
+        "qty": 1
+      },
+      {
+        "item": "silver",
+        "qty": 1
+      },
+      {
+        "item": "indium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 30
+    },
+    "timeSeconds": 288
+  },
+  {
+    "id": "chromatic_stellar_fusion_gold_silver_quartzite_48",
+    "name": "Chromatic Stellar Fusion",
+    "inputs": [
+      {
+        "item": "gold",
+        "qty": 1
+      },
+      {
+        "item": "silver",
+        "qty": 1
+      },
+      {
+        "item": "quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 30
+    },
+    "timeSeconds": 288
+  },
+  {
+    "id": "chromatic_stellar_fusion_gold_silver_copper_49",
+    "name": "Chromatic Stellar Fusion",
+    "inputs": [
+      {
+        "item": "gold",
+        "qty": 1
+      },
+      {
+        "item": "silver",
+        "qty": 1
+      },
+      {
+        "item": "copper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 5
+    },
+    "timeSeconds": 288
+  },
+  {
+    "id": "extract_chromatic_material_activated_copper_50",
+    "name": "Extract Chromatic Material",
+    "inputs": [
+      {
+        "item": "activated_copper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "extract_chromatic_material_cadmium_51",
+    "name": "Extract Chromatic Material",
+    "inputs": [
+      {
+        "item": "cadmium",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 1
+    },
+    "timeSeconds": 17
+  },
+  {
+    "id": "extract_chromatic_material_copper_52",
+    "name": "Extract Chromatic Material",
+    "inputs": [
+      {
+        "item": "copper",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "extract_chromatic_material_activated_cadmium_53",
+    "name": "Extract Chromatic Material",
+    "inputs": [
+      {
+        "item": "activated_cadmium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 2
+    },
+    "timeSeconds": 12
+  },
+  {
+    "id": "extract_chromatic_material_activated_emeril_54",
+    "name": "Extract Chromatic Material",
+    "inputs": [
+      {
+        "item": "activated_emeril",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 3
+    },
+    "timeSeconds": 10
+  },
+  {
+    "id": "extract_chromatic_material_emeril_55",
+    "name": "Extract Chromatic Material",
+    "inputs": [
+      {
+        "item": "emeril",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 3
+    },
+    "timeSeconds": 10
+  },
+  {
+    "id": "extract_chromatic_material_activated_quartzite_56",
+    "name": "Extract Chromatic Material",
+    "inputs": [
+      {
+        "item": "activated_quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 4
+    },
+    "timeSeconds": 6
+  },
+  {
+    "id": "extract_chromatic_material_indium_57",
+    "name": "Extract Chromatic Material",
+    "inputs": [
+      {
+        "item": "indium",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 4
+    },
+    "timeSeconds": 6
+  },
+  {
+    "id": "extract_chromatic_material_quartzite_58",
+    "name": "Extract Chromatic Material",
+    "inputs": [
+      {
+        "item": "quartzite",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 4
+    },
+    "timeSeconds": 6
+  },
+  {
+    "id": "extract_chromatic_material_activated_indium_59",
+    "name": "Extract Chromatic Material",
+    "inputs": [
+      {
+        "item": "activated_indium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "chromatic_metal",
+      "qty": 4
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "deionise_mineral_ionised_cobalt_60",
+    "name": "Deionise Mineral",
+    "inputs": [
+      {
+        "item": "ionised_cobalt",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "cobalt",
+      "qty": 2
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "algal_processing_cyto_phosphate_61",
+    "name": "Algal Processing",
+    "inputs": [
+      {
+        "item": "cyto_phosphate",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "condensed_carbon",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "condense_carbon_carbon_62",
+    "name": "Condense Carbon",
+    "inputs": [
+      {
+        "item": "carbon",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "condensed_carbon",
+      "qty": 1
+    },
+    "timeSeconds": 11
+  },
+  {
+    "id": "feed_microbes_faecium_carbon_63",
+    "name": "Feed Microbes",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "condensed_carbon",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "feed_microbes_faecium_mordite_64",
+    "name": "Feed Microbes",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "mordite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "condensed_carbon",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "feed_microbes_faecium_condensed_carbon_65",
+    "name": "Feed Microbes",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "condensed_carbon",
+      "qty": 3
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "harness_energy_uranium_di_hydrogen_66",
+    "name": "Harness Energy",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 1
+      },
+      {
+        "item": "di_hydrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "condensed_carbon",
+      "qty": 2
+    },
+    "timeSeconds": 2
+  },
+  {
+    "id": "oxygenate_carbon_carbon_oxygen_67",
+    "name": "Oxygenate Carbon",
+    "inputs": [
+      {
+        "item": "carbon",
+        "qty": 2
+      },
+      {
+        "item": "oxygen",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "condensed_carbon",
+      "qty": 5
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "oxygenate_carbon_condensed_carbon_oxygen_68",
+    "name": "Oxygenate Carbon",
+    "inputs": [
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "condensed_carbon",
+      "qty": 6
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_expansion_copper_chromatic_metal_69",
+    "name": "Chromatic Expansion",
+    "inputs": [
+      {
+        "item": "copper",
+        "qty": 1
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "copper",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_lithium_quartzite_70",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "lithium",
+        "qty": 1
+      },
+      {
+        "item": "quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystallised_helium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_lithium_activated_quartzite_71",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "lithium",
+        "qty": 1
+      },
+      {
+        "item": "activated_quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "crystallised_helium",
+      "qty": 2
+    },
+    "timeSeconds": 11
+  },
+  {
+    "id": "di_hydrogen_cycling_di_hydrogen_silicate_powder_72",
+    "name": "Di-hydrogen Cycling",
+    "inputs": [
+      {
+        "item": "di_hydrogen",
+        "qty": 1
+      },
+      {
+        "item": "silicate_powder",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "deuterium",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "di_hydrogen_cycling_di_hydrogen_tritium_73",
+    "name": "Di-hydrogen Cycling",
+    "inputs": [
+      {
+        "item": "di_hydrogen",
+        "qty": 1
+      },
+      {
+        "item": "tritium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "deuterium",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "di_hydrogen_cycling_di_hydrogen_jelly_74",
+    "name": "Di-hydrogen Cycling",
+    "inputs": [
+      {
+        "item": "di_hydrogen_jelly",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "di_hydrogen",
+      "qty": 40
+    },
+    "timeSeconds": 240
+  },
+  {
+    "id": "tritium_cycling_tritium_75",
+    "name": "Tritium Cycling",
+    "inputs": [
+      {
+        "item": "tritium",
+        "qty": 5
+      }
+    ],
+    "output": {
+      "item": "di_hydrogen",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "condense_di_hydrogen_di_hydrogen_76",
+    "name": "Condense Di-hydrogen",
+    "inputs": [
+      {
+        "item": "di_hydrogen",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "di_hydrogen_jelly",
+      "qty": 1
+    },
+    "timeSeconds": 3600
+  },
+  {
+    "id": "advanced_carbon_processing_carbon_sodium_nitrate_77",
+    "name": "Advanced Carbon Processing",
+    "inputs": [
+      {
+        "item": "carbon",
+        "qty": 1
+      },
+      {
+        "item": "sodium_nitrate",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "dioxite",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "advanced_carbon_processing_condensed_carbon_sodium_nitrate_78",
+    "name": "Advanced Carbon Processing",
+    "inputs": [
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      },
+      {
+        "item": "sodium_nitrate",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "dioxite",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_ammonia_ferrite_dust_79",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 2
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "dioxite",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_ammonia_pure_ferrite_80",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 2
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "dioxite",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "floral_titration_frost_crystal_salt_81",
+    "name": "Floral Titration",
+    "inputs": [
+      {
+        "item": "frost_crystal",
+        "qty": 2
+      },
+      {
+        "item": "salt",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "dioxite",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "alloy_latticing_pyrite_gold_ferrite_dust_82",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 30
+      },
+      {
+        "item": "gold",
+        "qty": 10
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 120
+      }
+    ],
+    "output": {
+      "item": "dirty_bronze",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_pyrite_gold_pure_ferrite_83",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 30
+      },
+      {
+        "item": "gold",
+        "qty": 10
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "dirty_bronze",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_pyrite_platinum_ferrite_dust_84",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 30
+      },
+      {
+        "item": "platinum",
+        "qty": 5
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 120
+      }
+    ],
+    "output": {
+      "item": "dirty_bronze",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_pyrite_platinum_pure_ferrite_85",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 30
+      },
+      {
+        "item": "platinum",
+        "qty": 5
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "dirty_bronze",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_pyrite_silver_ferrite_dust_86",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 30
+      },
+      {
+        "item": "silver",
+        "qty": 20
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 120
+      }
+    ],
+    "output": {
+      "item": "dirty_bronze",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_pyrite_silver_pure_ferrite_87",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 30
+      },
+      {
+        "item": "silver",
+        "qty": 20
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "dirty_bronze",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_pyrite_tritium_ferrite_dust_88",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 30
+      },
+      {
+        "item": "tritium",
+        "qty": 20
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 120
+      }
+    ],
+    "output": {
+      "item": "dirty_bronze",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_pyrite_tritium_pure_ferrite_89",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 30
+      },
+      {
+        "item": "tritium",
+        "qty": 20
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "dirty_bronze",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "chromatic_expansion_emeril_chromatic_metal_90",
+    "name": "Chromatic Expansion",
+    "inputs": [
+      {
+        "item": "emeril",
+        "qty": 1
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "emeril",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "high_speed_sublimation_radon_carbon_chlorine_91",
+    "name": "High-Speed Sublimation",
+    "inputs": [
+      {
+        "item": "radon",
+        "qty": 100
+      },
+      {
+        "item": "carbon",
+        "qty": 20
+      },
+      {
+        "item": "chlorine",
+        "qty": 5
+      }
+    ],
+    "output": {
+      "item": "enriched_carbon",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "high_speed_sublimation_radon_carbon_salt_92",
+    "name": "High-Speed Sublimation",
+    "inputs": [
+      {
+        "item": "radon",
+        "qty": 100
+      },
+      {
+        "item": "carbon",
+        "qty": 20
+      },
+      {
+        "item": "salt",
+        "qty": 10
+      }
+    ],
+    "output": {
+      "item": "enriched_carbon",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "high_speed_sublimation_radon_condensed_carbon_chlorine_93",
+    "name": "High-Speed Sublimation",
+    "inputs": [
+      {
+        "item": "radon",
+        "qty": 100
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 10
+      },
+      {
+        "item": "chlorine",
+        "qty": 5
+      }
+    ],
+    "output": {
+      "item": "enriched_carbon",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "high_speed_sublimation_radon_condensed_carbon_salt_94",
+    "name": "High-Speed Sublimation",
+    "inputs": [
+      {
+        "item": "radon",
+        "qty": 100
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 10
+      },
+      {
+        "item": "salt",
+        "qty": 10
+      }
+    ],
+    "output": {
+      "item": "enriched_carbon",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "assisted_decomposition_di_hydrogen_carbon_95",
+    "name": "Assisted Decomposition",
+    "inputs": [
+      {
+        "item": "di_hydrogen",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "faecium",
+      "qty": 1
+    },
+    "timeSeconds": 5
+  },
+  {
+    "id": "assisted_decomposition_mordite_96",
+    "name": "Assisted Decomposition",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 3
+      }
+    ],
+    "output": {
+      "item": "faecium",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "encourage_growth_nitrogen_sulphurine_97",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "nitrogen",
+        "qty": 1
+      },
+      {
+        "item": "sulphurine",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "faecium",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "organic_expansion_mordite_methane_98",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "faecium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "oxygenate_microbes_faecium_oxygen_99",
+    "name": "Oxygenate Microbes",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "faecium",
+      "qty": 3
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "runaway_decomposition_mordite_carbon_100",
+    "name": "Runaway Decomposition",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "faecium",
+      "qty": 3
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "runaway_decomposition_mordite_condensed_carbon_101",
+    "name": "Runaway Decomposition",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "faecium",
+      "qty": 4
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "ferrite_dust_extraction_ammonia_102",
+    "name": "Ferrite Dust Extraction",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ferrite_dust",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "ferrite_dust_extraction_crystallised_helium_103",
+    "name": "Ferrite Dust Extraction",
+    "inputs": [
+      {
+        "item": "crystallised_helium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ferrite_dust",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "ferrite_dust_extraction_dioxite_104",
+    "name": "Ferrite Dust Extraction",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ferrite_dust",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "ferrite_dust_extraction_lithium_105",
+    "name": "Ferrite Dust Extraction",
+    "inputs": [
+      {
+        "item": "lithium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ferrite_dust",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "ferrite_dust_extraction_paraffinium_106",
+    "name": "Ferrite Dust Extraction",
+    "inputs": [
+      {
+        "item": "paraffinium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ferrite_dust",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "ferrite_dust_extraction_phosphorus_107",
+    "name": "Ferrite Dust Extraction",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ferrite_dust",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "ferrite_dust_extraction_pyrite_108",
+    "name": "Ferrite Dust Extraction",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ferrite_dust",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "ferrite_dust_extraction_uranium_109",
+    "name": "Ferrite Dust Extraction",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ferrite_dust",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "recycle_waste_materials_rusted_metal_110",
+    "name": "Recycle Waste Materials",
+    "inputs": [
+      {
+        "item": "rusted_metal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ferrite_dust",
+      "qty": 2
+    },
+    "timeSeconds": 38
+  },
+  {
+    "id": "encourage_growth_dioxite_oxygen_111",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 2
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "frost_crystal",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "encourage_growth_dioxite_radon_112",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 1
+      },
+      {
+        "item": "radon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "frost_crystal",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_dioxite_methane_113",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "frost_crystal",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_frost_crystal_dioxite_114",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "dioxite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "frost_crystal",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "encourage_growth_ammonia_nitrogen_115",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 1
+      },
+      {
+        "item": "nitrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_mould",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "encourage_growth_ammonia_oxygen_116",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 2
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_mould",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_ammonia_methane_117",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_mould",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_fungal_mould_ammonia_118",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "fungal_mould",
+        "qty": 1
+      },
+      {
+        "item": "ammonia",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "fungal_mould",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "encourage_growth_uranium_radon_119",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 1
+      },
+      {
+        "item": "radon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gamma_root",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "encourage_growth_uranium_oxygen_120",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 2
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gamma_root",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_uranium_methane_121",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gamma_root",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_gamma_root_uranium_122",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "gamma_root",
+        "qty": 1
+      },
+      {
+        "item": "uranium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gamma_root",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "polish_crystals_frost_crystal_123",
+    "name": "Polish Crystals",
+    "inputs": [
+      {
+        "item": "frost_crystal",
+        "qty": 40
+      }
+    ],
+    "output": {
+      "item": "glass",
+      "qty": 1
+    },
+    "timeSeconds": 1800
+  },
+  {
+    "id": "salt_crystal_polishing_cyto_phosphate_salt_124",
+    "name": "Salt Crystal Polishing",
+    "inputs": [
+      {
+        "item": "cyto_phosphate",
+        "qty": 50
+      },
+      {
+        "item": "salt",
+        "qty": 50
+      }
+    ],
+    "output": {
+      "item": "glass",
+      "qty": 1
+    },
+    "timeSeconds": 600
+  },
+  {
+    "id": "silicate_forging_silicate_powder_125",
+    "name": "Silicate Forging",
+    "inputs": [
+      {
+        "item": "silicate_powder",
+        "qty": 40
+      }
+    ],
+    "output": {
+      "item": "glass",
+      "qty": 1
+    },
+    "timeSeconds": 300
+  },
+  {
+    "id": "alchemical_construction_faecium_residual_goop_126",
+    "name": "Alchemical Construction",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "residual_goop",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gold",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "alchemical_construction_hexite_127",
+    "name": "Alchemical Construction",
+    "inputs": [
+      {
+        "item": "hexite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gold",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "calcite_transmutation_living_pearl_128",
+    "name": "Calcite Transmutation",
+    "inputs": [
+      {
+        "item": "living_pearl",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gold",
+      "qty": 100
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "chromatic_alchemy_ferrite_dust_oxygen_emeril_129",
+    "name": "Chromatic Alchemy",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      },
+      {
+        "item": "emeril",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gold",
+      "qty": 10
+    },
+    "timeSeconds": 288
+  },
+  {
+    "id": "extreme_alloy_separation_grantine_130",
+    "name": "Extreme Alloy Separation",
+    "inputs": [
+      {
+        "item": "grantine",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gold",
+      "qty": 125
+    },
+    "timeSeconds": 72
+  },
+  {
+    "id": "extreme_alloy_separation_lemmium_131",
+    "name": "Extreme Alloy Separation",
+    "inputs": [
+      {
+        "item": "lemmium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gold",
+      "qty": 125
+    },
+    "timeSeconds": 72
+  },
+  {
+    "id": "extreme_alloy_separation_magno_gold_132",
+    "name": "Extreme Alloy Separation",
+    "inputs": [
+      {
+        "item": "magno_gold",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gold",
+      "qty": 125
+    },
+    "timeSeconds": 72
+  },
+  {
+    "id": "organic_anomaly_synthesis_mordite_pugneum_133",
+    "name": "Organic / Anomaly Synthesis",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "pugneum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gold",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "pugneum_alchemy_faecium_pugneum_134",
+    "name": "Pugneum Alchemy",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 1
+      },
+      {
+        "item": "pugneum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "gold",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "alloy_latticing_dioxite_gold_cobalt_135",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 30
+      },
+      {
+        "item": "gold",
+        "qty": 10
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "grantine",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_dioxite_gold_ionised_cobalt_136",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 30
+      },
+      {
+        "item": "gold",
+        "qty": 10
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "grantine",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_dioxite_platinum_cobalt_137",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 30
+      },
+      {
+        "item": "platinum",
+        "qty": 5
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "grantine",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_dioxite_platinum_ionised_cobalt_138",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 30
+      },
+      {
+        "item": "platinum",
+        "qty": 5
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "grantine",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_dioxite_silver_cobalt_139",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 30
+      },
+      {
+        "item": "silver",
+        "qty": 20
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "grantine",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_dioxite_silver_ionised_cobalt_140",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 30
+      },
+      {
+        "item": "silver",
+        "qty": 20
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "grantine",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_dioxite_tritium_cobalt_141",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 30
+      },
+      {
+        "item": "tritium",
+        "qty": 20
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "grantine",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_dioxite_tritium_ionised_cobalt_142",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 30
+      },
+      {
+        "item": "tritium",
+        "qty": 20
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "grantine",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_ammonia_gold_cobalt_143",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 30
+      },
+      {
+        "item": "gold",
+        "qty": 10
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "herox",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_ammonia_gold_ionised_cobalt_144",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 30
+      },
+      {
+        "item": "gold",
+        "qty": 10
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "herox",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_ammonia_platinum_cobalt_145",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 30
+      },
+      {
+        "item": "platinum",
+        "qty": 5
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "herox",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_ammonia_platinum_ionised_cobalt_146",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 30
+      },
+      {
+        "item": "platinum",
+        "qty": 5
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "herox",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_ammonia_silver_cobalt_147",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 30
+      },
+      {
+        "item": "silver",
+        "qty": 20
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "herox",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_ammonia_silver_ionised_cobalt_148",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 30
+      },
+      {
+        "item": "silver",
+        "qty": 20
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "herox",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_ammonia_tritium_cobalt_149",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 30
+      },
+      {
+        "item": "tritium",
+        "qty": 20
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "herox",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_ammonia_tritium_ionised_cobalt_150",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "ammonia",
+        "qty": 30
+      },
+      {
+        "item": "tritium",
+        "qty": 20
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "herox",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "chromatic_expansion_indium_chromatic_metal_151",
+    "name": "Chromatic Expansion",
+    "inputs": [
+      {
+        "item": "indium",
+        "qty": 1
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "indium",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "ion_capture_ferrite_dust_silver_sodium_152",
+    "name": "Ion Capture",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 10
+      },
+      {
+        "item": "silver",
+        "qty": 10
+      },
+      {
+        "item": "sodium",
+        "qty": 10
+      }
+    ],
+    "output": {
+      "item": "ion_battery",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "bonded_cobalt_extraction_marrow_bulb_oxygen_153",
+    "name": "Bonded Cobalt Extraction",
+    "inputs": [
+      {
+        "item": "marrow_bulb",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ionised_cobalt",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "efficient_cobalt_ionisation_cobalt_oxygen_154",
+    "name": "Efficient Cobalt Ionisation",
+    "inputs": [
+      {
+        "item": "cobalt",
+        "qty": 2
+      },
+      {
+        "item": "oxygen",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "ionised_cobalt",
+      "qty": 5
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "efficient_cobalt_ionisation_ionised_cobalt_oxygen_155",
+    "name": "Efficient Cobalt Ionisation",
+    "inputs": [
+      {
+        "item": "ionised_cobalt",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "ionised_cobalt",
+      "qty": 6
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "ionise_bulbs_cobalt_marrow_bulb_156",
+    "name": "Ionise Bulbs",
+    "inputs": [
+      {
+        "item": "cobalt",
+        "qty": 1
+      },
+      {
+        "item": "marrow_bulb",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ionised_cobalt",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "ionise_bulbs_ionised_cobalt_marrow_bulb_157",
+    "name": "Ionise Bulbs",
+    "inputs": [
+      {
+        "item": "ionised_cobalt",
+        "qty": 1
+      },
+      {
+        "item": "marrow_bulb",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ionised_cobalt",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "ionise_mineral_cobalt_158",
+    "name": "Ionise Mineral",
+    "inputs": [
+      {
+        "item": "cobalt",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "ionised_cobalt",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "pugneum_washing_marrow_bulb_pugneum_159",
+    "name": "Pugneum Washing",
+    "inputs": [
+      {
+        "item": "marrow_bulb",
+        "qty": 1
+      },
+      {
+        "item": "pugneum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "ionised_cobalt",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "encourage_growth_salt_nitrogen_160",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "salt",
+        "qty": 1
+      },
+      {
+        "item": "nitrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "kelp_sac",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "organic_expansion_lithium_methane_161",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "lithium",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "kelp_sac",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "alloy_latticing_uranium_gold_ferrite_dust_162",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 30
+      },
+      {
+        "item": "gold",
+        "qty": 10
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 120
+      }
+    ],
+    "output": {
+      "item": "lemmium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_uranium_gold_pure_ferrite_163",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 30
+      },
+      {
+        "item": "gold",
+        "qty": 10
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "lemmium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_uranium_platinum_ferrite_dust_164",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 30
+      },
+      {
+        "item": "platinum",
+        "qty": 5
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 120
+      }
+    ],
+    "output": {
+      "item": "lemmium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_uranium_platinum_pure_ferrite_165",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 30
+      },
+      {
+        "item": "platinum",
+        "qty": 5
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "lemmium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_uranium_silver_ferrite_dust_166",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 30
+      },
+      {
+        "item": "silver",
+        "qty": 20
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 120
+      }
+    ],
+    "output": {
+      "item": "lemmium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_uranium_silver_pure_ferrite_167",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 30
+      },
+      {
+        "item": "silver",
+        "qty": 20
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "lemmium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_uranium_tritium_ferrite_dust_168",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 30
+      },
+      {
+        "item": "tritium",
+        "qty": 20
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 120
+      }
+    ],
+    "output": {
+      "item": "lemmium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_uranium_tritium_pure_ferrite_169",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 30
+      },
+      {
+        "item": "tritium",
+        "qty": 20
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "lemmium",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "advanced_oxygen_capture_oxygen_condensed_carbon_di_hydrogen_170",
+    "name": "Advanced Oxygen Capture",
+    "inputs": [
+      {
+        "item": "oxygen",
+        "qty": 10
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 10
+      },
+      {
+        "item": "di_hydrogen",
+        "qty": 10
+      }
+    ],
+    "output": {
+      "item": "life_support_gel",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "environmental_element_transfer_crystallised_helium_quartzite_171",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "crystallised_helium",
+        "qty": 1
+      },
+      {
+        "item": "quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "lithium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_crystallised_helium_activated_quartzite_172",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "crystallised_helium",
+        "qty": 1
+      },
+      {
+        "item": "activated_quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "lithium",
+      "qty": 2
+    },
+    "timeSeconds": 11
+  },
+  {
+    "id": "biological_purge_hypnotic_eye_173",
+    "name": "Biological Purge",
+    "inputs": [
+      {
+        "item": "hypnotic_eye",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "living_slime",
+      "qty": 50
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "reanimation_mordite_atlantideum_174",
+    "name": "Reanimation",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 5
+      },
+      {
+        "item": "atlantideum",
+        "qty": 5
+      }
+    ],
+    "output": {
+      "item": "living_slime",
+      "qty": 1
+    },
+    "timeSeconds": 864
+  },
+  {
+    "id": "recycle_waste_materials_viscous_fluids_175",
+    "name": "Recycle Waste Materials",
+    "inputs": [
+      {
+        "item": "viscous_fluids",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "living_slime",
+      "qty": 1
+    },
+    "timeSeconds": 36
+  },
+  {
+    "id": "carbonise_metal_ferrite_dust_carbon_176",
+    "name": "Carbonise Metal",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "carbonise_metal_ferrite_dust_condensed_carbon_177",
+    "name": "Carbonise Metal",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 2
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "carbonise_metal_pure_ferrite_carbon_178",
+    "name": "Carbonise Metal",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 2
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "carbonise_metal_pure_ferrite_condensed_carbon_179",
+    "name": "Carbonise Metal",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 3
+    },
+    "timeSeconds": 5
+  },
+  {
+    "id": "deep_metal_compression_ferrite_dust_pure_ferrite_platinum_180",
+    "name": "Deep Metal Compression",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "platinum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 12
+    },
+    "timeSeconds": 2
+  },
+  {
+    "id": "deep_metal_compression_ferrite_dust_pure_ferrite_silver_181",
+    "name": "Deep Metal Compression",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "silver",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 5
+    },
+    "timeSeconds": 6
+  },
+  {
+    "id": "deep_metal_compression_ferrite_dust_pure_ferrite_gold_182",
+    "name": "Deep Metal Compression",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "gold",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 8
+    },
+    "timeSeconds": 4
+  },
+  {
+    "id": "magnetise_metal_pure_ferrite_183",
+    "name": "Magnetise Metal",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "matter_expansion_pure_ferrite_pugneum_184",
+    "name": "Matter Expansion",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 2
+      },
+      {
+        "item": "pugneum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 3
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "matter_expansion_magnetised_ferrite_pugneum_185",
+    "name": "Matter Expansion",
+    "inputs": [
+      {
+        "item": "magnetised_ferrite",
+        "qty": 3
+      },
+      {
+        "item": "pugneum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 4
+    },
+    "timeSeconds": 5
+  },
+  {
+    "id": "mineral_alchemy_platinum_oxygen_186",
+    "name": "Mineral Alchemy",
+    "inputs": [
+      {
+        "item": "platinum",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 10
+    },
+    "timeSeconds": 2
+  },
+  {
+    "id": "stellar_metal_fusion_ferrite_dust_copper_187",
+    "name": "Stellar / Metal Fusion",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "copper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "stellar_metal_fusion_ferrite_dust_activated_copper_188",
+    "name": "Stellar / Metal Fusion",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "activated_copper",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 2
+    },
+    "timeSeconds": 11
+  },
+  {
+    "id": "stellar_metal_fusion_ferrite_dust_cadmium_189",
+    "name": "Stellar / Metal Fusion",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "cadmium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 2
+    },
+    "timeSeconds": 11
+  },
+  {
+    "id": "stellar_metal_fusion_ferrite_dust_emeril_190",
+    "name": "Stellar / Metal Fusion",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "emeril",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 3
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "stellar_metal_fusion_ferrite_dust_activated_cadmium_191",
+    "name": "Stellar / Metal Fusion",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "activated_cadmium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 4
+    },
+    "timeSeconds": 5
+  },
+  {
+    "id": "stellar_metal_fusion_ferrite_dust_indium_192",
+    "name": "Stellar / Metal Fusion",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "indium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 4
+    },
+    "timeSeconds": 5
+  },
+  {
+    "id": "stellar_metal_fusion_ferrite_dust_quartzite_193",
+    "name": "Stellar / Metal Fusion",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 4
+    },
+    "timeSeconds": 5
+  },
+  {
+    "id": "stellar_metal_fusion_ferrite_dust_activated_emeril_194",
+    "name": "Stellar / Metal Fusion",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "activated_emeril",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 6
+    },
+    "timeSeconds": 4
+  },
+  {
+    "id": "stellar_metal_fusion_ferrite_dust_activated_indium_195",
+    "name": "Stellar / Metal Fusion",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "activated_indium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 8
+    },
+    "timeSeconds": 3
+  },
+  {
+    "id": "stellar_metal_fusion_ferrite_dust_activated_quartzite_196",
+    "name": "Stellar / Metal Fusion",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "activated_quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "magnetised_ferrite",
+      "qty": 8
+    },
+    "timeSeconds": 3
+  },
+  {
+    "id": "alloy_latticing_phosphorus_gold_cobalt_197",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 30
+      },
+      {
+        "item": "gold",
+        "qty": 10
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "magno_gold",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_phosphorus_gold_ionised_cobalt_198",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 30
+      },
+      {
+        "item": "gold",
+        "qty": 10
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "magno_gold",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_phosphorus_platinum_cobalt_199",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 30
+      },
+      {
+        "item": "platinum",
+        "qty": 5
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "magno_gold",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_phosphorus_platinum_ionised_cobalt_200",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 30
+      },
+      {
+        "item": "platinum",
+        "qty": 5
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "magno_gold",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_phosphorus_silver_cobalt_201",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 30
+      },
+      {
+        "item": "silver",
+        "qty": 20
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "magno_gold",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_phosphorus_silver_ionised_cobalt_202",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 30
+      },
+      {
+        "item": "silver",
+        "qty": 20
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "magno_gold",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_phosphorus_tritium_cobalt_203",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 30
+      },
+      {
+        "item": "tritium",
+        "qty": 20
+      },
+      {
+        "item": "cobalt",
+        "qty": 60
+      }
+    ],
+    "output": {
+      "item": "magno_gold",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "alloy_latticing_phosphorus_tritium_ionised_cobalt_204",
+    "name": "Alloy Latticing",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 30
+      },
+      {
+        "item": "tritium",
+        "qty": 20
+      },
+      {
+        "item": "ionised_cobalt",
+        "qty": 30
+      }
+    ],
+    "output": {
+      "item": "magno_gold",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "encourage_growth_cobalt_nitrogen_205",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "cobalt",
+        "qty": 1
+      },
+      {
+        "item": "nitrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marrow_bulb",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "fertiliser_synthesis_mordite_sodium_206",
+    "name": "Fertiliser Synthesis",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "sodium",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "marrow_bulb",
+      "qty": 3
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "fertiliser_synthesis_mordite_sodium_nitrate_207",
+    "name": "Fertiliser Synthesis",
+    "inputs": [
+      {
+        "item": "mordite",
+        "qty": 1
+      },
+      {
+        "item": "sodium_nitrate",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marrow_bulb",
+      "qty": 4
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_crystallised_helium_methane_208",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "crystallised_helium",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "marrow_bulb",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_fusion_nitrogen_sulphurine_radon_209",
+    "name": "Organic Fusion",
+    "inputs": [
+      {
+        "item": "nitrogen",
+        "qty": 3
+      },
+      {
+        "item": "sulphurine",
+        "qty": 3
+      },
+      {
+        "item": "radon",
+        "qty": 3
+      }
+    ],
+    "output": {
+      "item": "methane",
+      "qty": 1
+    },
+    "timeSeconds": 10
+  },
+  {
+    "id": "anomaly_organic_hybridisation_carbon_pugneum_210",
+    "name": "Anomaly / Organic Hybridisation",
+    "inputs": [
+      {
+        "item": "carbon",
+        "qty": 1
+      },
+      {
+        "item": "pugneum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mordite",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "anomaly_organic_hybridisation_condensed_carbon_pugneum_211",
+    "name": "Anomaly / Organic Hybridisation",
+    "inputs": [
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      },
+      {
+        "item": "pugneum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mordite",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_reassembly_di_hydrogen_condensed_carbon_212",
+    "name": "Organic Reassembly",
+    "inputs": [
+      {
+        "item": "di_hydrogen",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "mordite",
+      "qty": 1
+    },
+    "timeSeconds": 5
+  },
+  {
+    "id": "organic_reassembly_faecium_213",
+    "name": "Organic Reassembly",
+    "inputs": [
+      {
+        "item": "faecium",
+        "qty": 3
+      }
+    ],
+    "output": {
+      "item": "mordite",
+      "qty": 2
+    },
+    "timeSeconds": 43
+  },
+  {
+    "id": "alchemical_construction_hexite_faecium_214",
+    "name": "Alchemical Construction",
+    "inputs": [
+      {
+        "item": "hexite",
+        "qty": 1
+      },
+      {
+        "item": "faecium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "doom_cycling_tainted_metal_215",
+    "name": "Doom Cycling",
+    "inputs": [
+      {
+        "item": "tainted_metal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "doom_cycling_hadal_core_216",
+    "name": "Doom Cycling",
+    "inputs": [
+      {
+        "item": "hadal_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 50
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "loosen_bonds_flesh_rope_217",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "flesh_rope",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 50
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "loosen_bonds_vile_spawn_218",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "vile_spawn",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 50
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "nanite_extraction_salvaged_data_219",
+    "name": "Nanite Extraction",
+    "inputs": [
+      {
+        "item": "salvaged_data",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 15
+    },
+    "timeSeconds": 77
+  },
+  {
+    "id": "not_recommended_larval_core_220",
+    "name": "NOT RECOMMENDED",
+    "inputs": [
+      {
+        "item": "larval_core",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 50
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "purge_corruption_inverted_mirror_221",
+    "name": "Purge Corruption",
+    "inputs": [
+      {
+        "item": "inverted_mirror",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 95
+    },
+    "timeSeconds": 528
+  },
+  {
+    "id": "reality_filtering_pugneum_222",
+    "name": "Reality Filtering",
+    "inputs": [
+      {
+        "item": "pugneum",
+        "qty": 25
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 1
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "reality_warping_platinum_223",
+    "name": "Reality Warping",
+    "inputs": [
+      {
+        "item": "platinum",
+        "qty": 35
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "recycle_waste_materials_runaway_mould_224",
+    "name": "Recycle Waste Materials",
+    "inputs": [
+      {
+        "item": "runaway_mould",
+        "qty": 5
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 1
+    },
+    "timeSeconds": 36
+  },
+  {
+    "id": "sentience_extraction_hyaline_brain_225",
+    "name": "Sentience Extraction",
+    "inputs": [
+      {
+        "item": "hyaline_brain",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 230
+    },
+    "timeSeconds": 768
+  },
+  {
+    "id": "subjugation_of_glass_radiant_shard_226",
+    "name": "Subjugation of Glass",
+    "inputs": [
+      {
+        "item": "radiant_shard",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 50
+    },
+    "timeSeconds": 432
+  },
+  {
+    "id": "transmutation_platinum_gold_silver_227",
+    "name": "Transmutation",
+    "inputs": [
+      {
+        "item": "platinum",
+        "qty": 25
+      },
+      {
+        "item": "gold",
+        "qty": 15
+      },
+      {
+        "item": "silver",
+        "qty": 15
+      }
+    ],
+    "output": {
+      "item": "nanite_cluster",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_catalysation_methane_chromatic_metal_228",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "methane",
+        "qty": 1
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nitrogen",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_catalysation_radon_chromatic_metal_229",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "radon",
+        "qty": 1
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nitrogen",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_transfer_methane_230",
+    "name": "Gas Transfer",
+    "inputs": [
+      {
+        "item": "methane",
+        "qty": 3
+      }
+    ],
+    "output": {
+      "item": "nitrogen",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_transfer_methane_oxygen_231",
+    "name": "Gas Transfer",
+    "inputs": [
+      {
+        "item": "methane",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nitrogen",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_transfer_radon_232",
+    "name": "Gas Transfer",
+    "inputs": [
+      {
+        "item": "radon",
+        "qty": 3
+      }
+    ],
+    "output": {
+      "item": "nitrogen",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_transfer_radon_oxygen_233",
+    "name": "Gas Transfer",
+    "inputs": [
+      {
+        "item": "radon",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "nitrogen",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "high_speed_sublimation_nitrogen_condensed_carbon_chlorine_234",
+    "name": "High-Speed Sublimation",
+    "inputs": [
+      {
+        "item": "nitrogen",
+        "qty": 100
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 10
+      },
+      {
+        "item": "chlorine",
+        "qty": 5
+      }
+    ],
+    "output": {
+      "item": "nitrogen_salt",
+      "qty": 1
+    },
+    "timeSeconds": 600
+  },
+  {
+    "id": "high_speed_sublimation_nitrogen_carbon_chlorine_235",
+    "name": "High-Speed Sublimation",
+    "inputs": [
+      {
+        "item": "nitrogen",
+        "qty": 100
+      },
+      {
+        "item": "carbon",
+        "qty": 20
+      },
+      {
+        "item": "chlorine",
+        "qty": 5
+      }
+    ],
+    "output": {
+      "item": "nitrogen_salt",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "high_speed_sublimation_nitrogen_carbon_salt_236",
+    "name": "High-Speed Sublimation",
+    "inputs": [
+      {
+        "item": "nitrogen",
+        "qty": 100
+      },
+      {
+        "item": "carbon",
+        "qty": 20
+      },
+      {
+        "item": "salt",
+        "qty": 10
+      }
+    ],
+    "output": {
+      "item": "nitrogen_salt",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "high_speed_sublimation_nitrogen_condensed_carbon_salt_237",
+    "name": "High-Speed Sublimation",
+    "inputs": [
+      {
+        "item": "nitrogen",
+        "qty": 100
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 10
+      },
+      {
+        "item": "salt",
+        "qty": 10
+      }
+    ],
+    "output": {
+      "item": "nitrogen_salt",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "artificial_photosynthesis_cactus_flesh_kelp_sac_condensed_carbon_238",
+    "name": "Artificial Photosynthesis",
+    "inputs": [
+      {
+        "item": "cactus_flesh",
+        "qty": 1
+      },
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "oxygen",
+      "qty": 10
+    },
+    "timeSeconds": 216
+  },
+  {
+    "id": "artificial_photosynthesis_frost_crystal_kelp_sac_condensed_carbon_239",
+    "name": "Artificial Photosynthesis",
+    "inputs": [
+      {
+        "item": "frost_crystal",
+        "qty": 1
+      },
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "oxygen",
+      "qty": 10
+    },
+    "timeSeconds": 216
+  },
+  {
+    "id": "artificial_photosynthesis_fungal_mould_kelp_sac_condensed_carbon_240",
+    "name": "Artificial Photosynthesis",
+    "inputs": [
+      {
+        "item": "fungal_mould",
+        "qty": 1
+      },
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "oxygen",
+      "qty": 10
+    },
+    "timeSeconds": 216
+  },
+  {
+    "id": "artificial_photosynthesis_gamma_root_kelp_sac_condensed_carbon_241",
+    "name": "Artificial Photosynthesis",
+    "inputs": [
+      {
+        "item": "gamma_root",
+        "qty": 1
+      },
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "oxygen",
+      "qty": 10
+    },
+    "timeSeconds": 216
+  },
+  {
+    "id": "artificial_photosynthesis_solanium_kelp_sac_condensed_carbon_242",
+    "name": "Artificial Photosynthesis",
+    "inputs": [
+      {
+        "item": "solanium",
+        "qty": 1
+      },
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "oxygen",
+      "qty": 10
+    },
+    "timeSeconds": 216
+  },
+  {
+    "id": "artificial_photosynthesis_star_bulb_kelp_sac_condensed_carbon_243",
+    "name": "Artificial Photosynthesis",
+    "inputs": [
+      {
+        "item": "star_bulb",
+        "qty": 1
+      },
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "oxygen",
+      "qty": 10
+    },
+    "timeSeconds": 216
+  },
+  {
+    "id": "extract_micro_bubbles_kelp_sac_244",
+    "name": "Extract Micro-Bubbles",
+    "inputs": [
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "oxygen",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "release_captured_oxygen_kelp_sac_carbon_245",
+    "name": "Release Captured Oxygen",
+    "inputs": [
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "oxygen",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "release_captured_oxygen_kelp_sac_condensed_carbon_246",
+    "name": "Release Captured Oxygen",
+    "inputs": [
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "oxygen",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_pyrite_ferrite_dust_247",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 2
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "paraffinium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_pyrite_pure_ferrite_248",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "pyrite",
+        "qty": 2
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "paraffinium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "floral_titration_star_bulb_salt_249",
+    "name": "Floral Titration",
+    "inputs": [
+      {
+        "item": "star_bulb",
+        "qty": 2
+      },
+      {
+        "item": "salt",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "paraffinium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "loosen_bonds_sulphurine_ferrite_dust_250",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "sulphurine",
+        "qty": 1
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "paraffinium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "loosen_bonds_sulphurine_pure_ferrite_251",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "sulphurine",
+        "qty": 1
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "paraffinium",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "loosen_bonds_sulphurine_magnetised_ferrite_252",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "sulphurine",
+        "qty": 1
+      },
+      {
+        "item": "magnetised_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "paraffinium",
+      "qty": 3
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "mineral_alchemy_silver_oxygen_253",
+    "name": "Mineral Alchemy",
+    "inputs": [
+      {
+        "item": "silver",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "paraffinium",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_dioxite_ferrite_dust_254",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 2
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "phosphorus",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_dioxite_pure_ferrite_255",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "dioxite",
+        "qty": 2
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "phosphorus",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "floral_titration_solanium_salt_256",
+    "name": "Floral Titration",
+    "inputs": [
+      {
+        "item": "solanium",
+        "qty": 2
+      },
+      {
+        "item": "salt",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "phosphorus",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_fusion_methane_di_hydrogen_257",
+    "name": "Organic Fusion",
+    "inputs": [
+      {
+        "item": "methane",
+        "qty": 1
+      },
+      {
+        "item": "di_hydrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "phosphorus",
+      "qty": 1
+    },
+    "timeSeconds": 10
+  },
+  {
+    "id": "chromatic_alchemy_ferrite_dust_oxygen_chromatic_metal_258",
+    "name": "Chromatic Alchemy",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 250
+      }
+    ],
+    "output": {
+      "item": "platinum",
+      "qty": 10
+    },
+    "timeSeconds": 288
+  },
+  {
+    "id": "extreme_alloy_separation_geodesite_259",
+    "name": "Extreme Alloy Separation",
+    "inputs": [
+      {
+        "item": "geodesite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "platinum",
+      "qty": 250
+    },
+    "timeSeconds": 72
+  },
+  {
+    "id": "extreme_alloy_separation_iridesite_260",
+    "name": "Extreme Alloy Separation",
+    "inputs": [
+      {
+        "item": "iridesite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "platinum",
+      "qty": 250
+    },
+    "timeSeconds": 72
+  },
+  {
+    "id": "transmutation_silver_gold_261",
+    "name": "Transmutation",
+    "inputs": [
+      {
+        "item": "silver",
+        "qty": 1
+      },
+      {
+        "item": "gold",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "platinum",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "restore_harmony_atlantideum_262",
+    "name": "Restore Harmony",
+    "inputs": [
+      {
+        "item": "atlantideum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pugneum",
+      "qty": 2
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "demagnetise_metal_magnetised_ferrite_263",
+    "name": "Demagnetise Metal",
+    "inputs": [
+      {
+        "item": "magnetised_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pure_ferrite",
+      "qty": 2
+    },
+    "timeSeconds": 10
+  },
+  {
+    "id": "extract_metallic_elements_ferrite_dust_264",
+    "name": "Extract Metallic Elements",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pure_ferrite",
+      "qty": 1
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "matter_expansion_ferrite_dust_pugneum_265",
+    "name": "Matter Expansion",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 2
+      },
+      {
+        "item": "pugneum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pure_ferrite",
+      "qty": 3
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "recycle_stone_polished_stone_266",
+    "name": "Recycle Stone",
+    "inputs": [
+      {
+        "item": "polished_stone",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pure_ferrite",
+      "qty": 2
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "environmental_element_transfer_uranium_ferrite_dust_267",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 2
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pyrite",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_uranium_pure_ferrite_268",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "uranium",
+        "qty": 2
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pyrite",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "floral_titration_cactus_flesh_salt_269",
+    "name": "Floral Titration",
+    "inputs": [
+      {
+        "item": "cactus_flesh",
+        "qty": 2
+      },
+      {
+        "item": "salt",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pyrite",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "loosen_bonds_lithium_ferrite_dust_270",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "lithium",
+        "qty": 1
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pyrite",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "loosen_bonds_lithium_pure_ferrite_271",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "lithium",
+        "qty": 1
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pyrite",
+      "qty": 2
+    },
+    "timeSeconds": 11
+  },
+  {
+    "id": "loosen_bonds_lithium_magnetised_ferrite_272",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "lithium",
+        "qty": 1
+      },
+      {
+        "item": "magnetised_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pyrite",
+      "qty": 3
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "metal_restructuring_gold_273",
+    "name": "Metal Restructuring",
+    "inputs": [
+      {
+        "item": "gold",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pyrite",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "mineral_alchemy_gold_oxygen_274",
+    "name": "Mineral Alchemy",
+    "inputs": [
+      {
+        "item": "gold",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "pyrite",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "chromatic_alchemy_activated_quartzite_carbon_275",
+    "name": "Chromatic Alchemy",
+    "inputs": [
+      {
+        "item": "activated_quartzite",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "quartzite",
+      "qty": 1
+    },
+    "timeSeconds": 6
+  },
+  {
+    "id": "chromatic_expansion_quartzite_chromatic_metal_276",
+    "name": "Chromatic Expansion",
+    "inputs": [
+      {
+        "item": "quartzite",
+        "qty": 1
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "quartzite",
+      "qty": 2
+    },
+    "timeSeconds": 11
+  },
+  {
+    "id": "gas_catalysation_sulphurine_chromatic_metal_277",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "sulphurine",
+        "qty": 1
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "radon",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_transfer_sulphurine_278",
+    "name": "Gas Transfer",
+    "inputs": [
+      {
+        "item": "sulphurine",
+        "qty": 3
+      }
+    ],
+    "output": {
+      "item": "radon",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_transfer_sulphurine_oxygen_279",
+    "name": "Gas Transfer",
+    "inputs": [
+      {
+        "item": "sulphurine",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "radon",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "doom_cycling_cursed_dust_280",
+    "name": "Doom Cycling",
+    "inputs": [
+      {
+        "item": "cursed_dust",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "residual_goop",
+      "qty": 1
+    },
+    "timeSeconds": 2
+  },
+  {
+    "id": "reality_pollution_atlantideum_pugneum_281",
+    "name": "Reality Pollution",
+    "inputs": [
+      {
+        "item": "atlantideum",
+        "qty": 1
+      },
+      {
+        "item": "pugneum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "runaway_mould",
+      "qty": 3
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "recycle_waste_materials_living_slime_282",
+    "name": "Recycle Waste Materials",
+    "inputs": [
+      {
+        "item": "living_slime",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "runaway_mould",
+      "qty": 1
+    },
+    "timeSeconds": 36
+  },
+  {
+    "id": "oxidise_metal_oxygen_ferrite_dust_283",
+    "name": "Oxidise Metal",
+    "inputs": [
+      {
+        "item": "oxygen",
+        "qty": 1
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "rusted_metal",
+      "qty": 1
+    },
+    "timeSeconds": 24
+  },
+  {
+    "id": "oxidise_metal_oxygen_pure_ferrite_284",
+    "name": "Oxidise Metal",
+    "inputs": [
+      {
+        "item": "oxygen",
+        "qty": 1
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "rusted_metal",
+      "qty": 2
+    },
+    "timeSeconds": 24
+  },
+  {
+    "id": "rapid_formation_evaporation_di_hydrogen_oxygen_285",
+    "name": "Rapid Formation / Evaporation",
+    "inputs": [
+      {
+        "item": "di_hydrogen",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "salt",
+      "qty": 1
+    },
+    "timeSeconds": 5
+  },
+  {
+    "id": "salt_production_chlorine_286",
+    "name": "Salt Production",
+    "inputs": [
+      {
+        "item": "chlorine",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "salt",
+      "qty": 2
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "extreme_alloy_separation_herox_287",
+    "name": "Extreme Alloy Separation",
+    "inputs": [
+      {
+        "item": "herox",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "silver",
+      "qty": 250
+    },
     "timeSeconds": 60
   },
   {
-    "id": "nutrient_paste",
-    "name": "Nutrient Paste",
+    "id": "extreme_alloy_separation_aronium_288",
+    "name": "Extreme Alloy Separation",
     "inputs": [
-      {"item": "processed_meat", "qty": 1},
-      {"item": "fresh_milk", "qty": 1}
+      {
+        "item": "aronium",
+        "qty": 1
+      }
     ],
-    "output": {"item": "nutrient_paste", "qty": 1},
-    "timeSeconds": 40
+    "output": {
+      "item": "silver",
+      "qty": 250
+    },
+    "timeSeconds": 72
+  },
+  {
+    "id": "extreme_alloy_separation_dirty_bronze_289",
+    "name": "Extreme Alloy Separation",
+    "inputs": [
+      {
+        "item": "dirty_bronze",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "silver",
+      "qty": 250
+    },
+    "timeSeconds": 72
+  },
+  {
+    "id": "extract_organic_sodium_marrow_bulb_290",
+    "name": "Extract Organic Sodium",
+    "inputs": [
+      {
+        "item": "marrow_bulb",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "extract_organic_sodium_marrow_bulb_carbon_291",
+    "name": "Extract Organic Sodium",
+    "inputs": [
+      {
+        "item": "marrow_bulb",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "extract_organic_sodium_marrow_bulb_condensed_carbon_292",
+    "name": "Extract Organic Sodium",
+    "inputs": [
+      {
+        "item": "marrow_bulb",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "free_sodium_sodium_nitrate_293",
+    "name": "Free Sodium",
+    "inputs": [
+      {
+        "item": "sodium_nitrate",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium",
+      "qty": 2
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "catalyse_carbon_sodium_carbon_294",
+    "name": "Catalyse Carbon",
+    "inputs": [
+      {
+        "item": "sodium",
+        "qty": 1
+      },
+      {
+        "item": "carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "catalyse_carbon_sodium_condensed_carbon_295",
+    "name": "Catalyse Carbon",
+    "inputs": [
+      {
+        "item": "sodium",
+        "qty": 1
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "feed_microbes_sodium_nitrate_faecium_296",
+    "name": "Feed Microbes",
+    "inputs": [
+      {
+        "item": "sodium_nitrate",
+        "qty": 1
+      },
+      {
+        "item": "faecium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "feed_microbes_sodium_faecium_297",
+    "name": "Feed Microbes",
+    "inputs": [
+      {
+        "item": "sodium",
+        "qty": 1
+      },
+      {
+        "item": "faecium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_catalysation_sodium_methane_298",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "sodium",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_catalysation_sodium_nitrogen_299",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "sodium",
+        "qty": 1
+      },
+      {
+        "item": "nitrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_catalysation_ferrite_dust_methane_300",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 1
+    },
+    "timeSeconds": 29
+  },
+  {
+    "id": "gas_catalysation_ferrite_dust_nitrogen_301",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      },
+      {
+        "item": "nitrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 1
+    },
+    "timeSeconds": 29
+  },
+  {
+    "id": "gas_catalysation_sodium_nitrate_methane_302",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "sodium_nitrate",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 11
+  },
+  {
+    "id": "gas_catalysation_sodium_nitrate_nitrogen_303",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "sodium_nitrate",
+        "qty": 1
+      },
+      {
+        "item": "nitrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 11
+  },
+  {
+    "id": "gas_catalysation_pure_ferrite_methane_304",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "gas_catalysation_pure_ferrite_nitrogen_305",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "nitrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "gas_catalysation_magnetised_ferrite_methane_306",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "magnetised_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 3
+    },
+    "timeSeconds": 10
+  },
+  {
+    "id": "gas_catalysation_magnetised_ferrite_nitrogen_307",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "magnetised_ferrite",
+        "qty": 1
+      },
+      {
+        "item": "nitrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 3
+    },
+    "timeSeconds": 10
+  },
+  {
+    "id": "harness_organic_nitrogren_sodium_nitrate_kelp_sac_308",
+    "name": "Harness Organic Nitrogren",
+    "inputs": [
+      {
+        "item": "sodium_nitrate",
+        "qty": 1
+      },
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "harness_organic_nitrogren_sodium_nitrate_marrow_bulb_309",
+    "name": "Harness Organic Nitrogren",
+    "inputs": [
+      {
+        "item": "sodium_nitrate",
+        "qty": 1
+      },
+      {
+        "item": "marrow_bulb",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "harness_organic_nitrogren_sodium_kelp_sac_310",
+    "name": "Harness Organic Nitrogren",
+    "inputs": [
+      {
+        "item": "sodium",
+        "qty": 1
+      },
+      {
+        "item": "kelp_sac",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "harness_organic_nitrogren_sodium_marrow_bulb_311",
+    "name": "Harness Organic Nitrogren",
+    "inputs": [
+      {
+        "item": "sodium",
+        "qty": 1
+      },
+      {
+        "item": "marrow_bulb",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "loosen_bonds_methane_crystallised_helium_activated_quartzite_312",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "methane",
+        "qty": 1
+      },
+      {
+        "item": "crystallised_helium",
+        "qty": 1
+      },
+      {
+        "item": "activated_quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 11
+  },
+  {
+    "id": "loosen_bonds_methane_lithium_activated_quartzite_313",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "methane",
+        "qty": 1
+      },
+      {
+        "item": "lithium",
+        "qty": 1
+      },
+      {
+        "item": "activated_quartzite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 11
+  },
+  {
+    "id": "oxygenate_sodium_sodium_oxygen_314",
+    "name": "Oxygenate Sodium",
+    "inputs": [
+      {
+        "item": "sodium",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "oxygenate_sodium_sodium_nitrate_oxygen_315",
+    "name": "Oxygenate Sodium",
+    "inputs": [
+      {
+        "item": "sodium_nitrate",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "process_sodium_sodium_316",
+    "name": "Process Sodium",
+    "inputs": [
+      {
+        "item": "sodium",
+        "qty": 2
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 1
+    },
+    "timeSeconds": 24
+  },
+  {
+    "id": "sentinel_catalysation_sodium_pugneum_317",
+    "name": "Sentinel Catalysation",
+    "inputs": [
+      {
+        "item": "sodium",
+        "qty": 1
+      },
+      {
+        "item": "pugneum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "sentinel_catalysation_sodium_nitrate_pugneum_318",
+    "name": "Sentinel Catalysation",
+    "inputs": [
+      {
+        "item": "sodium_nitrate",
+        "qty": 1
+      },
+      {
+        "item": "pugneum",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 3
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "sulphur_release_crystal_sulphide_319",
+    "name": "Sulphur Release",
+    "inputs": [
+      {
+        "item": "crystal_sulphide",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sodium_nitrate",
+      "qty": 50
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "encourage_growth_phosphorus_sulphurine_320",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 1
+      },
+      {
+        "item": "sulphurine",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "solanium",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "encourage_growth_phosphorus_oxygen_321",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 2
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "solanium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_phosphorus_methane_322",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "solanium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_solanium_phosphorus_323",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "solanium",
+        "qty": 1
+      },
+      {
+        "item": "phosphorus",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "solanium",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "sulphur_injection_di_hydrogen_sulphurine_324",
+    "name": "Sulphur Injection",
+    "inputs": [
+      {
+        "item": "di_hydrogen",
+        "qty": 1
+      },
+      {
+        "item": "sulphurine",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "solanium",
+      "qty": 1
+    },
+    "timeSeconds": 10
+  },
+  {
+    "id": "encourage_growth_paraffinium_nitrogen_325",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "paraffinium",
+        "qty": 1
+      },
+      {
+        "item": "nitrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "star_bulb",
+      "qty": 1
+    },
+    "timeSeconds": 14
+  },
+  {
+    "id": "encourage_growth_paraffinium_oxygen_326",
+    "name": "Encourage Growth",
+    "inputs": [
+      {
+        "item": "paraffinium",
+        "qty": 2
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "star_bulb",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_paraffinium_methane_327",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "paraffinium",
+        "qty": 1
+      },
+      {
+        "item": "methane",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "star_bulb",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "organic_expansion_star_bulb_paraffinium_328",
+    "name": "Organic Expansion",
+    "inputs": [
+      {
+        "item": "star_bulb",
+        "qty": 1
+      },
+      {
+        "item": "paraffinium",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "star_bulb",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "di_hydrogen_capture_di_hydrogen_ferrite_dust_sodium_nitrate_329",
+    "name": "Di-hydrogen Capture",
+    "inputs": [
+      {
+        "item": "di_hydrogen",
+        "qty": 10
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 20
+      },
+      {
+        "item": "sodium_nitrate",
+        "qty": 5
+      }
+    ],
+    "output": {
+      "item": "starship_launch_fuel",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "di_hydrogen_capture_di_hydrogen_magnetised_ferrite_sodium_nitrate_330",
+    "name": "Di-hydrogen Capture",
+    "inputs": [
+      {
+        "item": "di_hydrogen",
+        "qty": 10
+      },
+      {
+        "item": "magnetised_ferrite",
+        "qty": 10
+      },
+      {
+        "item": "sodium_nitrate",
+        "qty": 5
+      }
+    ],
+    "output": {
+      "item": "starship_launch_fuel",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "di_hydrogen_capture_di_hydrogen_pure_ferrite_sodium_331",
+    "name": "Di-hydrogen Capture",
+    "inputs": [
+      {
+        "item": "di_hydrogen",
+        "qty": 10
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 20
+      },
+      {
+        "item": "sodium",
+        "qty": 10
+      }
+    ],
+    "output": {
+      "item": "starship_launch_fuel",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "gas_catalysation_nitrogen_chromatic_metal_332",
+    "name": "Gas Catalysation",
+    "inputs": [
+      {
+        "item": "nitrogen",
+        "qty": 1
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sulphurine",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_transfer_nitrogen_333",
+    "name": "Gas Transfer",
+    "inputs": [
+      {
+        "item": "nitrogen",
+        "qty": 3
+      }
+    ],
+    "output": {
+      "item": "sulphurine",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "gas_transfer_nitrogen_oxygen_334",
+    "name": "Gas Transfer",
+    "inputs": [
+      {
+        "item": "nitrogen",
+        "qty": 1
+      },
+      {
+        "item": "oxygen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "sulphurine",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "high_speed_sublimation_sulphurine_carbon_chlorine_335",
+    "name": "High-Speed Sublimation",
+    "inputs": [
+      {
+        "item": "sulphurine",
+        "qty": 100
+      },
+      {
+        "item": "carbon",
+        "qty": 20
+      },
+      {
+        "item": "chlorine",
+        "qty": 5
+      }
+    ],
+    "output": {
+      "item": "thermic_condensate",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "high_speed_sublimation_sulphurine_carbon_salt_336",
+    "name": "High-Speed Sublimation",
+    "inputs": [
+      {
+        "item": "sulphurine",
+        "qty": 100
+      },
+      {
+        "item": "carbon",
+        "qty": 20
+      },
+      {
+        "item": "salt",
+        "qty": 10
+      }
+    ],
+    "output": {
+      "item": "thermic_condensate",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "high_speed_sublimation_sulphurine_condensed_carbon_chlorine_337",
+    "name": "High-Speed Sublimation",
+    "inputs": [
+      {
+        "item": "sulphurine",
+        "qty": 100
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 10
+      },
+      {
+        "item": "chlorine",
+        "qty": 5
+      }
+    ],
+    "output": {
+      "item": "thermic_condensate",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "high_speed_sublimation_sulphurine_condensed_carbon_salt_338",
+    "name": "High-Speed Sublimation",
+    "inputs": [
+      {
+        "item": "sulphurine",
+        "qty": 100
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 10
+      },
+      {
+        "item": "salt",
+        "qty": 10
+      }
+    ],
+    "output": {
+      "item": "thermic_condensate",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "plasma_pressurisation_oxygen_carbon_ferrite_dust_339",
+    "name": "Plasma Pressurisation",
+    "inputs": [
+      {
+        "item": "oxygen",
+        "qty": 10
+      },
+      {
+        "item": "carbon",
+        "qty": 20
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 20
+      }
+    ],
+    "output": {
+      "item": "unstable_plasma",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "plasma_pressurisation_oxygen_carbon_pure_ferrite_340",
+    "name": "Plasma Pressurisation",
+    "inputs": [
+      {
+        "item": "oxygen",
+        "qty": 10
+      },
+      {
+        "item": "carbon",
+        "qty": 20
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 20
+      }
+    ],
+    "output": {
+      "item": "unstable_plasma",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "plasma_pressurisation_oxygen_condensed_carbon_ferrite_dust_341",
+    "name": "Plasma Pressurisation",
+    "inputs": [
+      {
+        "item": "oxygen",
+        "qty": 10
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 10
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 20
+      }
+    ],
+    "output": {
+      "item": "unstable_plasma",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "plasma_pressurisation_oxygen_condensed_carbon_pure_ferrite_342",
+    "name": "Plasma Pressurisation",
+    "inputs": [
+      {
+        "item": "oxygen",
+        "qty": 10
+      },
+      {
+        "item": "condensed_carbon",
+        "qty": 10
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 20
+      }
+    ],
+    "output": {
+      "item": "unstable_plasma",
+      "qty": 1
+    },
+    "timeSeconds": 2700
+  },
+  {
+    "id": "catalyse_radiation_radon_di_hydrogen_343",
+    "name": "Catalyse Radiation",
+    "inputs": [
+      {
+        "item": "radon",
+        "qty": 1
+      },
+      {
+        "item": "di_hydrogen",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "uranium",
+      "qty": 1
+    },
+    "timeSeconds": 10
+  },
+  {
+    "id": "environmental_element_transfer_phosphorus_ferrite_dust_344",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 2
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "uranium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "environmental_element_transfer_phosphorus_pure_ferrite_345",
+    "name": "Environmental Element Transfer",
+    "inputs": [
+      {
+        "item": "phosphorus",
+        "qty": 2
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "uranium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "floral_titration_gamma_root_salt_346",
+    "name": "Floral Titration",
+    "inputs": [
+      {
+        "item": "gamma_root",
+        "qty": 2
+      },
+      {
+        "item": "salt",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "uranium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "loosen_bonds_crystallised_helium_ferrite_dust_347",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "crystallised_helium",
+        "qty": 1
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "uranium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "loosen_bonds_crystallised_helium_pure_ferrite_348",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "crystallised_helium",
+        "qty": 1
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "uranium",
+      "qty": 2
+    },
+    "timeSeconds": 11
+  },
+  {
+    "id": "loosen_bonds_crystallised_helium_magnetised_ferrite_349",
+    "name": "Loosen Bonds",
+    "inputs": [
+      {
+        "item": "crystallised_helium",
+        "qty": 1
+      },
+      {
+        "item": "magnetised_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "uranium",
+      "qty": 3
+    },
+    "timeSeconds": 7
+  },
+  {
+    "id": "metal_enrichment_radon_ferrite_dust_350",
+    "name": "Metal Enrichment",
+    "inputs": [
+      {
+        "item": "radon",
+        "qty": 1
+      },
+      {
+        "item": "ferrite_dust",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "uranium",
+      "qty": 1
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "metal_enrichment_radon_pure_ferrite_351",
+    "name": "Metal Enrichment",
+    "inputs": [
+      {
+        "item": "radon",
+        "qty": 1
+      },
+      {
+        "item": "pure_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "uranium",
+      "qty": 2
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "metal_enrichment_radon_magnetised_ferrite_352",
+    "name": "Metal Enrichment",
+    "inputs": [
+      {
+        "item": "radon",
+        "qty": 1
+      },
+      {
+        "item": "magnetised_ferrite",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "uranium",
+      "qty": 3
+    },
+    "timeSeconds": 22
+  },
+  {
+    "id": "recycle_waste_materials_residual_goop_353",
+    "name": "Recycle Waste Materials",
+    "inputs": [
+      {
+        "item": "residual_goop",
+        "qty": 1
+      }
+    ],
+    "output": {
+      "item": "viscous_fluids",
+      "qty": 1
+    },
+    "timeSeconds": 36
+  },
+  {
+    "id": "antimatter_bypass_carbon_sodium_nitrate_chromatic_metal_354",
+    "name": "Antimatter Bypass",
+    "inputs": [
+      {
+        "item": "carbon",
+        "qty": 50
+      },
+      {
+        "item": "sodium_nitrate",
+        "qty": 5
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 250
+      }
+    ],
+    "output": {
+      "item": "warp_cell",
+      "qty": 1
+    },
+    "timeSeconds": 18000
+  },
+  {
+    "id": "antimatter_bypass_condensed_carbon_sodium_nitrate_chromatic_metal_355",
+    "name": "Antimatter Bypass",
+    "inputs": [
+      {
+        "item": "condensed_carbon",
+        "qty": 25
+      },
+      {
+        "item": "sodium_nitrate",
+        "qty": 5
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 250
+      }
+    ],
+    "output": {
+      "item": "warp_cell",
+      "qty": 1
+    },
+    "timeSeconds": 18000
+  },
+  {
+    "id": "antimatter_bypass_condensed_carbon_sodium_chromatic_metal_356",
+    "name": "Antimatter Bypass",
+    "inputs": [
+      {
+        "item": "condensed_carbon",
+        "qty": 25
+      },
+      {
+        "item": "sodium",
+        "qty": 10
+      },
+      {
+        "item": "chromatic_metal",
+        "qty": 250
+      }
+    ],
+    "output": {
+      "item": "warp_cell",
+      "qty": 1
+    },
+    "timeSeconds": 18000
   }
 ]

--- a/src/data/tech.json
+++ b/src/data/tech.json
@@ -1,54 +1,8148 @@
 [
   {
-    "id": "pulse_engine",
-    "name": "Pulse Engine",
+    "id": "ablative_armour",
+    "name": "Ablative Armour",
+    "platform": "ship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ship",
+      "shield"
+    ]
+  },
+  {
+    "id": "accelerated_fire_sigma",
+    "name": "Accelerated Fire Sigma",
     "platform": "starship",
     "slotType": "tech",
-    "baseValue": 120,
-    "adjacency": {
-      "pulse_engine": 20,
-      "hyperdrive": 15
-    },
-    "superchargeMultiplier": 1.3,
-    "tags": ["mobility"]
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "accelerated_fire_tau",
+    "name": "Accelerated Fire Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "accelerated_fire_theta",
+    "name": "Accelerated Fire Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "advanced_cooling_sigma",
+    "name": "Advanced Cooling Sigma",
+    "platform": "general",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": []
+  },
+  {
+    "id": "advanced_cooling_tau",
+    "name": "Advanced Cooling Tau",
+    "platform": "general",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": []
+  },
+  {
+    "id": "advanced_cooling_theta",
+    "name": "Advanced Cooling Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "advanced_exocraft_laser",
+    "name": "Advanced Exocraft Laser",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "weapon_upgrades"
+    ]
+  },
+  {
+    "id": "advanced_launch_system",
+    "name": "Advanced Launch System",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "advanced_mining_laser",
+    "name": "Advanced Mining Laser",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "advanced_translator",
+    "name": "Advanced Translator",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "aeration_membrane",
+    "name": "Aeration Membrane",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "life_support"
+    ]
+  },
+  {
+    "id": "aeration_membrane_next",
+    "name": "Aeration Membrane (NEXT)",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "life_support"
+    ]
+  },
+  {
+    "id": "aeration_membrane_sigma",
+    "name": "Aeration Membrane Sigma",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "life_support"
+    ]
+  },
+  {
+    "id": "aeration_membrane_tau",
+    "name": "Aeration Membrane Tau",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "life_support"
+    ]
+  },
+  {
+    "id": "aeration_membrane_theta",
+    "name": "Aeration Membrane Theta",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "life_support"
+    ]
+  },
+  {
+    "id": "aeron_shield",
+    "name": "Aeron Shield",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "shield"
+    ]
+  },
+  {
+    "id": "air_filtration_unit",
+    "name": "Air Filtration Unit",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle"
+    ]
+  },
+  {
+    "id": "airburst_engine",
+    "name": "Airburst Engine",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "movement"
+    ]
+  },
+  {
+    "id": "alternator",
+    "name": "Alternator",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "amplified_cartridges",
+    "name": "Amplified Cartridges",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "amplified_warp_shielding",
+    "name": "Amplified Warp Shielding",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "analysis_visor",
+    "name": "Analysis Visor",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "analysis_visor_upgrade",
+    "name": "Analysis Visor Upgrade",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "analysis_visor"
+    ]
+  },
+  {
+    "id": "ancient_lock",
+    "name": "Ancient Lock",
+    "platform": "artifact",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "artifact"
+    ]
+  },
+  {
+    "id": "animus_beam",
+    "name": "Animus Beam",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "anomaly_suppressor",
+    "name": "Anomaly Suppressor",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "hazard"
+    ]
+  },
+  {
+    "id": "aqua_jets",
+    "name": "Aqua-Jets",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "launch_thruster"
+    ]
+  },
+  {
+    "id": "arc_of_cursumburg",
+    "name": "Arc of Cursumburg",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "ariadnes_flame",
+    "name": "Ariadne's Flame",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle"
+    ]
+  },
+  {
+    "id": "artemis_translator",
+    "name": "Artemis' Translator",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "ashidaka_uyll_mark_xvi",
+    "name": "Ashidaka-Uyll Mark XVI",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "atlantid_drive",
+    "name": "Atlantid Drive",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "atmospheric_control_unit",
+    "name": "Atmospheric Control Unit",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "life_support"
+    ]
+  },
+  {
+    "id": "automatic_translation_device",
+    "name": "Automatic translation device",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "ballistic_plating_v4",
+    "name": "Ballistic Plating V4",
+    "platform": "ship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ship",
+      "health"
+    ]
+  },
+  {
+    "id": "barrel_ioniser",
+    "name": "Barrel Ioniser",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "beam_amplifier",
+    "name": "Beam Amplifier",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "laser"
+    ]
+  },
+  {
+    "id": "beam_coolant_system",
+    "name": "Beam Coolant System",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "laser"
+    ]
+  },
+  {
+    "id": "beam_coolant_system_sigma",
+    "name": "Beam Coolant System Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "mining_beam"
+    ]
+  },
+  {
+    "id": "beam_coolant_system_tau",
+    "name": "Beam Coolant System Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "mining_beam"
+    ]
+  },
+  {
+    "id": "beam_coolant_system_theta",
+    "name": "Beam Coolant System Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "mining_beam"
+    ]
+  },
+  {
+    "id": "beam_focus_sigma",
+    "name": "Beam Focus Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "laser"
+    ]
+  },
+  {
+    "id": "beam_focus_tau",
+    "name": "Beam Focus Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "laser"
+    ]
+  },
+  {
+    "id": "beam_focus_theta",
+    "name": "Beam Focus Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "laser"
+    ]
+  },
+  {
+    "id": "beam_focus_v1",
+    "name": "Beam Focus V1",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "laser"
+    ]
+  },
+  {
+    "id": "beam_focus_v2",
+    "name": "Beam Focus V2",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "laser"
+    ]
+  },
+  {
+    "id": "beam_focus_v3",
+    "name": "Beam Focus V3",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "laser"
+    ]
+  },
+  {
+    "id": "beam_impact_sigma",
+    "name": "Beam Impact Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapon"
+    ]
+  },
+  {
+    "id": "beam_impact_tau",
+    "name": "Beam Impact Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapon"
+    ]
+  },
+  {
+    "id": "beam_impact_theta",
+    "name": "Beam Impact Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "beam_intensifier_sigma",
+    "name": "Beam Intensifier Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "laser"
+    ]
+  },
+  {
+    "id": "beam_intensifier_tau",
+    "name": "Beam Intensifier Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "mining_beam"
+    ]
+  },
+  {
+    "id": "beam_intensifier_theta",
+    "name": "Beam Intensifier Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "mining_beam"
+    ]
+  },
+  {
+    "id": "bio_input_sensor",
+    "name": "Bio-Input Sensor",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "blaze_javelin",
+    "name": "Blaze Javelin",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "energy_beam"
+    ]
+  },
+  {
+    "id": "blaze_javelin_atlas",
+    "name": "Blaze Javelin (Atlas)",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "energy_beam"
+    ]
+  },
+  {
+    "id": "blaze_javelin_coolant_sigma",
+    "name": "Blaze Javelin Coolant Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "blaze_javelin"
+    ]
+  },
+  {
+    "id": "blaze_javelin_coolant_tau",
+    "name": "Blaze Javelin Coolant Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "blaze_javelin"
+    ]
+  },
+  {
+    "id": "blaze_javelin_damage_sigma",
+    "name": "Blaze Javelin Damage Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "blaze_javelin"
+    ]
+  },
+  {
+    "id": "blaze_javelin_damage_tau",
+    "name": "Blaze Javelin Damage Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "blaze_javelin"
+    ]
+  },
+  {
+    "id": "blaze_javelin_damage_theta",
+    "name": "Blaze Javelin Damage Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "blaze_javelin"
+    ]
+  },
+  {
+    "id": "blaze_javelin_drill_array_sigma",
+    "name": "Blaze Javelin Drill Array Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "blaze_javelin"
+    ]
+  },
+  {
+    "id": "blaze_javelin_drill_array_tau",
+    "name": "Blaze Javelin Drill Array Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "blaze_javelin"
+    ]
+  },
+  {
+    "id": "blaze_javelin_drill_array_theta",
+    "name": "Blaze Javelin Drill Array Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "blaze_javelin"
+    ]
+  },
+  {
+    "id": "blaze_javelin_upgrade",
+    "name": "Blaze Javelin Upgrade",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "blown_transistor",
+    "name": "Blown Transistor",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool"
+    ]
+  },
+  {
+    "id": "boiler_unit",
+    "name": "Boiler Unit",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "boltcaster",
+    "name": "Boltcaster",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "boltcaster_atlas",
+    "name": "Boltcaster (Atlas)",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "boltcaster_clip_sigma",
+    "name": "Boltcaster Clip Sigma",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "projectile"
+    ]
+  },
+  {
+    "id": "boltcaster_clip_tau",
+    "name": "Boltcaster Clip Tau",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "projectile"
+    ]
+  },
+  {
+    "id": "boltcaster_clip_theta",
+    "name": "Boltcaster Clip Theta",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "projectile"
+    ]
+  },
+  {
+    "id": "boltcaster_ricochet_module",
+    "name": "Boltcaster Ricochet Module",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "boltcaster_sm",
+    "name": "Boltcaster SM",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "boltcaster_upgrade",
+    "name": "Boltcaster Upgrade",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "bomcdevir_mark_iv",
+    "name": "Bomcdevir Mark IV",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "burnt_out_compressor",
+    "name": "Burnt-Out Compressor",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "c28_m_fading_gleam",
+    "name": "C28/M Fading Gleam",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "cadmium_drive",
+    "name": "Cadmium Drive",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "cannon_damage_sigma",
+    "name": "Cannon Damage Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cannon_damage_tau",
+    "name": "Cannon Damage Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cannon_damage_theta",
+    "name": "Cannon Damage Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cargo_scan_deflector",
+    "name": "Cargo Scan Deflector",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "interplanetary"
+    ]
+  },
+  {
+    "id": "certain_ulgadello_lulai",
+    "name": "Certain Ulgadello-Lulai",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "charge_cylinder",
+    "name": "Charge Cylinder",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "power_supply"
+    ]
+  },
+  {
+    "id": "chloroplast_membrane",
+    "name": "Chloroplast Membrane",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "launch_system"
+    ]
+  },
+  {
+    "id": "chloroplast_membrane_implant",
+    "name": "Chloroplast Membrane Implant",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "launch_system"
+    ]
+  },
+  {
+    "id": "chromatic_warp_shielding",
+    "name": "Chromatic Warp Shielding",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "ci8_m66_vibrant_casting",
+    "name": "CI8/M66 Vibrant Casting",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "clarity_of_totaguri",
+    "name": "Clarity of Totaguri",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "cloaking_device",
+    "name": "Cloaking Device",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "combat_amplifier_omega",
+    "name": "Combat Amplifier Omega",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "mining_beam"
+    ]
+  },
+  {
+    "id": "combat_amplifier_sigma",
+    "name": "Combat Amplifier Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "mining_beam"
+    ]
+  },
+  {
+    "id": "combat_amplifier_tau",
+    "name": "Combat Amplifier Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "mining_beam"
+    ]
+  },
+  {
+    "id": "combat_amplifier_theta",
+    "name": "Combat Amplifier Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "mining_beam"
+    ]
+  },
+  {
+    "id": "combat_scope",
+    "name": "Combat Scope",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "precision"
+    ]
+  },
+  {
+    "id": "comforting_luovutus_purc",
+    "name": "Comforting Luovutus Purc",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "comforting_magarzello",
+    "name": "Comforting Magarzello",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "comforting_theory_x",
+    "name": "Comforting Theory X",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "complete_casting_xiii",
+    "name": "Complete Casting XIII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "concept_of_signasin_xuccl",
+    "name": "Concept of Signasin-Xuccl",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "conflict_scanner",
+    "name": "Conflict Scanner",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "scanner"
+    ]
+  },
+  {
+    "id": "containment_failure",
+    "name": "Containment Failure",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "coolant_network",
+    "name": "Coolant Network",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "coolant_network_next",
+    "name": "Coolant Network (NEXT)",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "coolant_network_sigma",
+    "name": "Coolant Network Sigma",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "coolant_network_tau",
+    "name": "Coolant Network Tau",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "coolant_network_theta",
+    "name": "Coolant Network Theta",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "cooling_system",
+    "name": "Cooling System",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "cooling_system_frigate",
+    "name": "Cooling System (Frigate)",
+    "platform": "frigate",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "frigate"
+    ]
+  },
+  {
+    "id": "corroded_tanks",
+    "name": "Corroded Tanks",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "corrupt_module",
+    "name": "Corrupt Module",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool"
+    ]
+  },
+  {
+    "id": "crimson_freighter_trail",
+    "name": "Crimson Freighter Trail",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter"
+    ]
+  },
+  {
+    "id": "cyclotron_ballista",
+    "name": "Cyclotron Ballista",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cyclotron_ballista_coolant_sigma",
+    "name": "Cyclotron Ballista Coolant Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cyclotron_ballista_coolant_tau",
+    "name": "Cyclotron Ballista Coolant Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cyclotron_ballista_coolant_theta",
+    "name": "Cyclotron Ballista Coolant Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cyclotron_ballista_damage_sigma",
+    "name": "Cyclotron Ballista Damage Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cyclotron_ballista_damage_tau",
+    "name": "Cyclotron Ballista Damage Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cyclotron_ballista_damage_theta",
+    "name": "Cyclotron Ballista Damage Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cyclotron_ballista_fire_rate_sigma",
+    "name": "Cyclotron Ballista Fire Rate Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cyclotron_ballista_fire_rate_tau",
+    "name": "Cyclotron Ballista Fire Rate Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cyclotron_ballista_fire_rate_theta",
+    "name": "Cyclotron Ballista Fire Rate Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "cyclotron_ballista_upgrade",
+    "name": "Cyclotron Ballista Upgrade",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "daedalus_engine",
+    "name": "Daedalus Engine",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "daedalus_engine_upgrade",
+    "name": "Daedalus Engine Upgrade",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "daedalus_engine"
+    ]
+  },
+  {
+    "id": "damage_radius",
+    "name": "Damage Radius",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "grenade"
+    ]
+  },
+  {
+    "id": "damage_radius_tau",
+    "name": "Damage Radius Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "grenade"
+    ]
+  },
+  {
+    "id": "damaged_electrode",
+    "name": "Damaged Electrode",
+    "platform": "drop_pod",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "drop_pod"
+    ]
+  },
+  {
+    "id": "damaged_gears",
+    "name": "Damaged Gears",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "damaged_wiring",
+    "name": "Damaged Wiring",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool"
+    ]
+  },
+  {
+    "id": "dayzhenyov_kosh_v2_1",
+    "name": "Dayzhenyov-kosh v2.1",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "defence_systems_upgrade",
+    "name": "Defence Systems Upgrade",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "defence_systems"
+    ]
+  },
+  {
+    "id": "defiant_recoil_ii",
+    "name": "Defiant Recoil II",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "deflection_enhancement_sigma",
+    "name": "Deflection Enhancement Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "health"
+    ]
+  },
+  {
+    "id": "deflection_enhancement_tau",
+    "name": "Deflection Enhancement Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "health"
+    ]
+  },
+  {
+    "id": "deflection_enhancement_theta",
+    "name": "Deflection Enhancement Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "health"
+    ]
+  },
+  {
+    "id": "deflector_shield",
+    "name": "Deflector Shield",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "shield"
+    ]
+  },
+  {
+    "id": "deflector_shield_atlas",
+    "name": "Deflector Shield (Atlas)",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "health"
+    ]
+  },
+  {
+    "id": "deflector_shield_upgrade",
+    "name": "Deflector Shield Upgrade",
+    "platform": "ship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ship",
+      "shield"
+    ]
+  },
+  {
+    "id": "dredging_laser",
+    "name": "Dredging Laser",
+    "platform": "aquatic",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "aquatic",
+      "nautilon"
+    ]
+  },
+  {
+    "id": "drift_suspension",
+    "name": "Drift Suspension",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "handling"
+    ]
+  },
+  {
+    "id": "dustadtte_mark_ii",
+    "name": "Dustadtte Mark II",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scrimshaw"
+    ]
+  },
+  {
+    "id": "dyson_pump",
+    "name": "Dyson Pump",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "economy_scanner",
+    "name": "Economy Scanner",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "scanner"
+    ]
+  },
+  {
+    "id": "efficient_thrusters",
+    "name": "Efficient Thrusters",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "launch_thruster"
+    ]
+  },
+  {
+    "id": "efficient_water_jets",
+    "name": "Efficient Water Jets",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "movement"
+    ]
+  },
+  {
+    "id": "emergency_warp_unit",
+    "name": "Emergency Warp Unit",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "emeril_drive",
+    "name": "Emeril Drive",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "environment_control_unit",
+    "name": "Environment Control Unit",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle"
+    ]
+  },
+  {
+    "id": "exceptional_intuition_vii",
+    "name": "Exceptional Intuition VII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "exo_skiff",
+    "name": "Exo-Skiff",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "exocraft_boosters",
+    "name": "Exocraft Boosters",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle"
+    ]
+  },
+  {
+    "id": "exocraft_boosters_upgrade",
+    "name": "Exocraft Boosters Upgrade",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "boosters_module"
+    ]
+  },
+  {
+    "id": "exocraft_boosters_upgrade_sigma",
+    "name": "Exocraft Boosters Upgrade Sigma",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "utilities"
+    ]
+  },
+  {
+    "id": "exocraft_boosters_upgrade_tau",
+    "name": "Exocraft Boosters Upgrade Tau",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "utilities"
+    ]
+  },
+  {
+    "id": "exocraft_mining_laser",
+    "name": "Exocraft Mining Laser",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle"
+    ]
+  },
+  {
+    "id": "exocraft_mining_laser_upgrade",
+    "name": "Exocraft Mining Laser Upgrade",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "mining_laser"
+    ]
+  },
+  {
+    "id": "exocraft_radar",
+    "name": "Exocraft Radar",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "communications"
+    ]
+  },
+  {
+    "id": "exocraft_summoning_unit",
+    "name": "Exocraft Summoning Unit",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "experiment_13j_v",
+    "name": "Experiment 13J/V",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "experiment_37c_97o",
+    "name": "Experiment 37C/97O",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "experiment_5_zv2",
+    "name": "Experiment 5-ZV2",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "experiment_6_5",
+    "name": "Experiment 6/5",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "experiment_b_3",
+    "name": "Experiment B/3",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "experiment_b_9",
+    "name": "Experiment B/9",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "experiment_j_a21",
+    "name": "Experiment J/A21",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "experiment_js9_7",
+    "name": "Experiment JS9-7",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "experiment_k_7",
+    "name": "Experiment K/7",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "experiment_ra1_kg8",
+    "name": "Experiment RA1 KG8",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "experiment_t32_j",
+    "name": "Experiment T32-J",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "experiment_y_f15",
+    "name": "Experiment Y-F15",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "exploded_panel",
+    "name": "Exploded Panel",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "fadilims_mark_xv",
+    "name": "Fadilims Mark XV",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "fading_plaarkto_ipio",
+    "name": "Fading Plaarkto-Ipio",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "fading_rucadrumm",
+    "name": "Fading Rucadrumm",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "faulty_hologram",
+    "name": "Faulty Hologram",
+    "platform": "drop_pod",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "drop_pod"
+    ]
+  },
+  {
+    "id": "fauna_analyzer_sigma",
+    "name": "Fauna Analyzer Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "fauna_analyzer_tau",
+    "name": "Fauna Analyzer Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "fauna_analyzer_theta",
+    "name": "Fauna Analyzer Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "fetirlitsre_mark_xix",
+    "name": "Fetirlitsre Mark XIX",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "final_riposte_i",
+    "name": "Final Riposte I",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "fishing_rig",
+    "name": "Fishing Rig",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "angling_equipment"
+    ]
+  },
+  {
+    "id": "fleeting_daanseon_uzan",
+    "name": "Fleeting Daanseon-Uzan",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "fleeting_enetinoser_dede",
+    "name": "Fleeting Enetinoser-Dede",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "fleeting_johrididja_ains",
+    "name": "Fleeting Johrididja-Ains",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "flight_assist_override",
+    "name": "Flight Assist Override",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "interplanetary"
+    ]
+  },
+  {
+    "id": "flora_analyzer_sigma",
+    "name": "Flora Analyzer Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "flora_analyzer_tau",
+    "name": "Flora Analyzer Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "flora_analyzer_theta",
+    "name": "Flora Analyzer Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "forbidden_exosuit_module",
+    "name": "Forbidden Exosuit Module",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "forbidden_multi_tool_module",
+    "name": "Forbidden Multi-Tool Module",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool"
+    ]
+  },
+  {
+    "id": "fourier_de_limiter",
+    "name": "Fourier De-Limiter",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "fragment_supercharger",
+    "name": "Fragment Supercharger",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "frameshift_catapult",
+    "name": "Frameshift Catapult",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "freighter_hyperdrive",
+    "name": "Freighter Hyperdrive",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "freighter_warp_reactor_sigma",
+    "name": "Freighter Warp Reactor Sigma",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "freighter_warp_reactor_tau",
+    "name": "Freighter Warp Reactor Tau",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "freighter_warp_reactor_theta",
+    "name": "Freighter Warp Reactor Theta",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "fuel_inverter",
+    "name": "Fuel Inverter",
+    "platform": "general",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": []
+  },
+  {
+    "id": "fuel_pump",
+    "name": "Fuel Pump",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "furnace_tank",
+    "name": "Furnace Tank",
+    "platform": "general",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": []
+  },
+  {
+    "id": "fusion_engine",
+    "name": "Fusion Engine",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "core_systems"
+    ]
+  },
+  {
+    "id": "fusion_engine_upgrade",
+    "name": "Fusion Engine Upgrade",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "fusion_engine"
+    ]
+  },
+  {
+    "id": "g38_jp6_elevated_loop",
+    "name": "G38-JP6 Elevated Loop",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "generator_coupling",
+    "name": "Generator Coupling",
+    "platform": "general",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": []
+  },
+  {
+    "id": "geology_cannon",
+    "name": "Geology Cannon",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "grenade"
+    ]
+  },
+  {
+    "id": "geology_cannon_upgrade",
+    "name": "Geology Cannon Upgrade",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "gift_of_auhetena",
+    "name": "Gift of Auhetena",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "gift_of_jarjeluse_ebro",
+    "name": "Gift of Jarjeluse-Ebro",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "glyph_1_16",
+    "name": "Glyph 1 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_10_16",
+    "name": "Glyph 10 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_11_16",
+    "name": "Glyph 11 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_12_16",
+    "name": "Glyph 12 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_13_16",
+    "name": "Glyph 13 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_14_16",
+    "name": "Glyph 14 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_15_16",
+    "name": "Glyph 15 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_16_16",
+    "name": "Glyph 16 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_2_16",
+    "name": "Glyph 2 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_3_16",
+    "name": "Glyph 3 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_4_16",
+    "name": "Glyph 4 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_5_16",
+    "name": "Glyph 5 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_6_16",
+    "name": "Glyph 6 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_7_16",
+    "name": "Glyph 7 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_8_16",
+    "name": "Glyph 8 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "glyph_9_16",
+    "name": "Glyph 9 / 16",
+    "platform": "ancient_technology",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ancient_technology"
+    ]
+  },
+  {
+    "id": "grafted_eyes",
+    "name": "Grafted Eyes",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "gravity_of_enoharaz",
+    "name": "Gravity of Enoharaz",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "grenade_intensity_sigma",
+    "name": "Grenade Intensity Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "grenade"
+    ]
+  },
+  {
+    "id": "grenade_intensity_tau",
+    "name": "Grenade Intensity Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "grenade"
+    ]
+  },
+  {
+    "id": "grenade_intensity_theta",
+    "name": "Grenade Intensity Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "grenade"
+    ]
+  },
+  {
+    "id": "grenade_propulsion",
+    "name": "Grenade Propulsion",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "grenade"
+    ]
+  },
+  {
+    "id": "grenade_propulsion_tau",
+    "name": "Grenade Propulsion Tau",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "grenade"
+    ]
+  },
+  {
+    "id": "grip_boost_suspension",
+    "name": "Grip Boost Suspension",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "handling"
+    ]
+  },
+  {
+    "id": "hardframe_body",
+    "name": "Hardframe Body",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "hardframe_left_arm",
+    "name": "Hardframe Left Arm",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "hardframe_legs",
+    "name": "Hardframe Legs",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "hardframe_right_arm",
+    "name": "Hardframe Right Arm",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "harmony_of_gudhiekt_mydo",
+    "name": "Harmony of Gudhiekt-Mydo",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "haz_mat_gauntlet",
+    "name": "Haz-Mat Gauntlet",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "hazard_protection",
+    "name": "Hazard Protection",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "hazard"
+    ]
+  },
+  {
+    "id": "health_module_sigma",
+    "name": "Health Module Sigma",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "health"
+    ]
+  },
+  {
+    "id": "health_module_tau",
+    "name": "Health Module Tau",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "health"
+    ]
+  },
+  {
+    "id": "health_module_theta",
+    "name": "Health Module Theta",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "health"
+    ]
+  },
+  {
+    "id": "hetyembran_fabar_mark_vii",
+    "name": "Hetyembran-Fabar Mark VII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "hi_slide_suspension",
+    "name": "Hi-Slide Suspension",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "handling"
+    ]
+  },
+  {
+    "id": "hidden_nutverdis_upug",
+    "name": "Hidden Nutverdis-Upug",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "high_gravity_freighter_trail",
+    "name": "High-Gravity Freighter Trail",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter"
+    ]
+  },
+  {
+    "id": "high_power_sonar",
+    "name": "High-Power Sonar",
+    "platform": "aquatic",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "aquatic"
+    ]
+  },
+  {
+    "id": "homing_grenade",
+    "name": "Homing Grenade",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "plasma_launcher_companion_unit"
+    ]
+  },
+  {
+    "id": "homingbolt_adaptor",
+    "name": "Homingbolt Adaptor",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "hull_fracture",
+    "name": "Hull Fracture",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "humboldt_drive",
+    "name": "Humboldt Drive",
+    "platform": "aquatic",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "aquatic"
+    ]
+  },
+  {
+    "id": "humboldt_drive_upgrade",
+    "name": "Humboldt Drive Upgrade",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "humboldt_drive"
+    ]
+  },
+  {
+    "id": "hunter_of_netsukaido_cutyl",
+    "name": "Hunter of Netsukaido Cutyl",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "hydraulics_damage",
+    "name": "Hydraulics Damage",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
   },
   {
     "id": "hyperdrive",
     "name": "Hyperdrive",
     "platform": "starship",
     "slotType": "tech",
-    "baseValue": 160,
-    "adjacency": {
-      "pulse_engine": 12,
-      "hyperdrive": 25
-    },
-    "superchargeMultiplier": 1.35,
-    "tags": ["warp"]
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
   },
   {
-    "id": "launch_thrusters",
-    "name": "Launch Thrusters",
+    "id": "hyperdrive_atlas",
+    "name": "Hyperdrive (Atlas)",
     "platform": "starship",
     "slotType": "tech",
-    "baseValue": 90,
-    "adjacency": {
-      "pulse_engine": 8,
-      "shield_life_support": 5
-    },
-    "superchargeMultiplier": 1.25,
-    "tags": ["utility"]
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
   },
   {
-    "id": "shield_life_support",
-    "name": "Deflector Shield",
+    "id": "hyperdrive_upgrade",
+    "name": "Hyperdrive Upgrade",
     "platform": "starship",
     "slotType": "tech",
-    "baseValue": 140,
-    "adjacency": {
-      "shield_life_support": 18,
-      "launch_thrusters": 6
-    },
-    "superchargeMultiplier": 1.4,
-    "tags": ["defense"]
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "icarus_fuel_system",
+    "name": "Icarus Fuel System",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "illegal_hazard_protection_upgrade",
+    "name": "Illegal Hazard Protection Upgrade",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "hazard"
+    ]
+  },
+  {
+    "id": "impact_damage_omega",
+    "name": "Impact Damage Omega",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "impact_damage_sigma",
+    "name": "Impact Damage Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "impact_damage_tau",
+    "name": "Impact Damage Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "impact_damage_theta",
+    "name": "Impact Damage Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "impact_igniter",
+    "name": "Impact Igniter",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "impulse_of_iogamagao_eutr",
+    "name": "Impulse of Iogamagao-Eutr",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "incinerator",
+    "name": "Incinerator",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "indium_drive",
+    "name": "Indium Drive",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "infra_knife_accelerator",
+    "name": "Infra-Knife Accelerator",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "infra_knife_accelerator_coolant_sigma",
+    "name": "Infra-Knife Accelerator Coolant Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "infra_knife_accelerator_coolant_tau",
+    "name": "Infra-Knife Accelerator Coolant Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "infra_knife_accelerator_coolant_theta",
+    "name": "Infra-Knife Accelerator Coolant Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "infra_knife_accelerator_damage_sigma",
+    "name": "Infra-Knife Accelerator Damage Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "infra_knife_accelerator_damage_tau",
+    "name": "Infra-Knife Accelerator Damage Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "infra_knife_accelerator_damage_theta",
+    "name": "Infra-Knife Accelerator Damage Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "infra_knife_accelerator_fire_rate_sigma",
+    "name": "Infra-Knife Accelerator Fire Rate Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "infra_knife_accelerator_fire_rate_tau",
+    "name": "Infra-Knife Accelerator Fire Rate Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "infra_knife_accelerator_fire_rate_theta",
+    "name": "Infra-Knife Accelerator Fire Rate Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "infra_knife_accelerator_upgrade",
+    "name": "Infra-Knife Accelerator Upgrade",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "input_terminal",
+    "name": "Input Terminal",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "instability_drive",
+    "name": "Instability Drive",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "interplanetary"
+    ]
+  },
+  {
+    "id": "interstellar_scanner",
+    "name": "Interstellar Scanner",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "scanner"
+    ]
+  },
+  {
+    "id": "inversion_of_ilkulovoma",
+    "name": "Inversion of Ilkulovoma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "inversion_of_prudiiwei_winse",
+    "name": "Inversion of Prudiiwei-Winse",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "ion_blast",
+    "name": "Ion Blast",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "ion_propulsion_v1",
+    "name": "Ion Propulsion V1",
+    "platform": "ship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ship",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "j_a_defiant_path",
+    "name": "J/A Defiant Path",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "jetpack",
+    "name": "Jetpack",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "jetpack_booster_sigma",
+    "name": "Jetpack Booster Sigma",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "jetpack_booster_tau",
+    "name": "Jetpack Booster Tau",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "jetpack_booster_theta",
+    "name": "Jetpack Booster Theta",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "kaviraiji_cair_mark_ix",
+    "name": "Kaviraiji-Cair Mark IX",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "l75_4_subdued_theory",
+    "name": "L75-4 Subdued Theory",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "lahariist_mark_xvii",
+    "name": "Lahariist Mark XVII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "land_disruptor",
+    "name": "Land Disruptor",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "grenade"
+    ]
+  },
+  {
+    "id": "large_rocket_tubes",
+    "name": "Large Rocket Tubes",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "launch_auto_charger",
+    "name": "Launch Auto-Charger",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "launch_thruster"
+    ]
+  },
+  {
+    "id": "launch_thruster",
+    "name": "Launch Thruster",
+    "platform": "propulsion",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "propulsion",
+      "enhancement"
+    ]
+  },
+  {
+    "id": "launch_thruster_upgrade",
+    "name": "Launch Thruster Upgrade",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "launch_thruster"
+    ]
+  },
+  {
+    "id": "life_support",
+    "name": "Life Support",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "core_systems"
+    ]
+  },
+  {
+    "id": "life_support_module_sigma",
+    "name": "Life Support Module Sigma",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "life_support_module_tau",
+    "name": "Life Support Module Tau",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "life_support_upgrade",
+    "name": "Life Support Upgrade",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "life_support"
+    ]
+  },
+  {
+    "id": "liquidator_body",
+    "name": "Liquidator Body",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "liquidator_left_arm",
+    "name": "Liquidator Left Arm",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "liquidator_legs",
+    "name": "Liquidator Legs",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "liquidator_right_arm",
+    "name": "Liquidator Right Arm",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "load_balancer",
+    "name": "Load Balancer",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "locking_mechanism",
+    "name": "Locking Mechanism",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "loom_damage",
+    "name": "Loom Damage",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool"
+    ]
+  },
+  {
+    "id": "lost_anglers_rig",
+    "name": "Lost Angler's Rig",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "angling_equipment"
+    ]
+  },
+  {
+    "id": "lucid_hunter_xix",
+    "name": "Lucid Hunter XIX",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "lucid_prayer_vi",
+    "name": "Lucid Prayer VI",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "magnetic_lock",
+    "name": "Magnetic Lock",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "mark_of_the_denier",
+    "name": "Mark of the Denier",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "health"
+    ]
+  },
+  {
+    "id": "mark_xix",
+    "name": "Mark XIX",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "mass_accelerator",
+    "name": "Mass Accelerator",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "master_circuit",
+    "name": "Master Circuit",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "master_circuit_frigate",
+    "name": "Master Circuit (Frigate)",
+    "platform": "frigate",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "frigate"
+    ]
+  },
+  {
+    "id": "matter_beam",
+    "name": "Matter Beam",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "megawatt_heater",
+    "name": "Megawatt Heater",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle"
+    ]
+  },
+  {
+    "id": "melted_fuel_cell",
+    "name": "Melted Fuel Cell",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "mercurial_angle_vi",
+    "name": "Mercurial Angle VI",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "minelaser",
+    "name": "MineLaser",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "laser"
+    ]
+  },
+  {
+    "id": "mineral_processing_rig",
+    "name": "Mineral Processing Rig",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "colossus"
+    ]
+  },
+  {
+    "id": "mining_beam",
+    "name": "Mining Beam",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "mining_beam_atlas",
+    "name": "Mining Beam (Atlas)",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "laser"
+    ]
+  },
+  {
+    "id": "mining_beam_upgrade",
+    "name": "Mining Beam Upgrade",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "minotaur_ai_pilot",
+    "name": "Minotaur AI Pilot",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "minotaur_bore",
+    "name": "Minotaur Bore",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "minotaur_cannon",
+    "name": "Minotaur Cannon",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "minotaur_cannon_upgrade",
+    "name": "Minotaur Cannon Upgrade",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "minotaur_cannon"
+    ]
+  },
+  {
+    "id": "minotaur_flamethrower_upgrade",
+    "name": "Minotaur Flamethrower Upgrade",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "minotaur_flamethrower"
+    ]
+  },
+  {
+    "id": "minotaur_laser",
+    "name": "Minotaur Laser",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "minotaur_laser_upgrade",
+    "name": "Minotaur Laser Upgrade",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "minotaur_laser"
+    ]
+  },
+  {
+    "id": "minotaur_radar_array",
+    "name": "Minotaur Radar Array",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "moskojin_xorc_mark_xviii",
+    "name": "Moskojin-Xorc Mark XVIII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "mounted_cannon",
+    "name": "Mounted Cannon",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "weapons"
+    ]
+  },
+  {
+    "id": "mounted_cannon_upgrade",
+    "name": "Mounted Cannon Upgrade",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "mounted_cannon"
+    ]
+  },
+  {
+    "id": "mounted_cannon_upgrade_sigma",
+    "name": "Mounted Cannon Upgrade Sigma",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "weapon_upgrades"
+    ]
+  },
+  {
+    "id": "mounted_flamethrower",
+    "name": "Mounted Flamethrower",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft"
+    ]
+  },
+  {
+    "id": "movement_system_upgrade",
+    "name": "Movement System Upgrade",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "movement_system"
+    ]
+  },
+  {
+    "id": "nautilon_cannon",
+    "name": "Nautilon Cannon",
+    "platform": "aquatic",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "aquatic"
+    ]
+  },
+  {
+    "id": "nautilon_cannon_upgrade",
+    "name": "Nautilon Cannon Upgrade",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "nautilon_cannon"
+    ]
+  },
+  {
+    "id": "network_interface",
+    "name": "Network Interface",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "neural_assembly",
+    "name": "Neural Assembly",
+    "platform": "propulsion",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "propulsion",
+      "enhancement"
+    ]
+  },
+  {
+    "id": "neural_shielding",
+    "name": "Neural Shielding",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "scan_deflector"
+    ]
+  },
+  {
+    "id": "neural_shielding_implant",
+    "name": "Neural Shielding Implant",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "scan_deflector"
+    ]
+  },
+  {
+    "id": "neural_stimulator",
+    "name": "Neural Stimulator",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "movement"
+    ]
+  },
+  {
+    "id": "neutron_cannon",
+    "name": "Neutron Cannon",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool"
+    ]
+  },
+  {
+    "id": "neutron_cannon_upgrade",
+    "name": "Neutron Cannon Upgrade",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "neutron_cannon"
+    ]
+  },
+  {
+    "id": "neutron_shielding",
+    "name": "Neutron Shielding",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle"
+    ]
+  },
+  {
+    "id": "nm5_iq7_complete_angle",
+    "name": "NM5-IQ7 Complete Angle",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "nonlinear_optics",
+    "name": "Nonlinear Optics",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "nonlinear_optics_infra_knife_accelerator",
+    "name": "Nonlinear Optics (Infra-Knife Accelerator)",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "nutrient_ingestor",
+    "name": "Nutrient Ingestor",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "o_l_complete_inversion",
+    "name": "O/L Complete Inversion",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "obedient_loop_xvii",
+    "name": "Obedient Loop XVII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "obsolete_technology",
+    "name": "Obsolete Technology",
+    "platform": "exosuit_starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit_starship"
+    ]
+  },
+  {
+    "id": "odvinsko_iayi_v7_28",
+    "name": "Odvinsko-Iayi V7.28",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "oebardsub_lesc_mark_xiii",
+    "name": "Oebardsub Lesc Mark XIII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "ofitsial_uilo_v4_0",
+    "name": "Ofitsial uilo V4.0",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "ogliaobei_urge_mark_xiii",
+    "name": "Ogliaobei-Urge Mark XIII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "optical_drill",
+    "name": "Optical Drill",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "osmotic_generator",
+    "name": "Osmotic Generator",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle"
+    ]
+  },
+  {
+    "id": "output_screen",
+    "name": "Output Screen",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "oxygen_recycler",
+    "name": "Oxygen Recycler",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "life_support"
+    ]
+  },
+  {
+    "id": "oxygen_rerouter",
+    "name": "Oxygen Rerouter",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "life_support"
+    ]
+  },
+  {
+    "id": "p_field_compressor",
+    "name": "P-Field Compressor",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "paralysis_mortar",
+    "name": "Paralysis Mortar",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "grenade"
+    ]
+  },
+  {
+    "id": "path_of_devertage_noff",
+    "name": "Path of Devertage-Noff",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "path_of_deyneseg",
+    "name": "Path of Deyneseg",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "pearl_offering",
+    "name": "Pearl Offering",
+    "platform": "artifact",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "artifact"
+    ]
+  },
+  {
+    "id": "personal_forcefield",
+    "name": "Personal Forcefield",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "shield"
+    ]
+  },
+  {
+    "id": "personal_refiner",
+    "name": "Personal Refiner",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "personal_refiner_mk_2",
+    "name": "Personal Refiner Mk 2",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "phase_beam",
+    "name": "Phase Beam",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "phase_beam_atlas",
+    "name": "Phase Beam (Atlas)",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "laser"
+    ]
+  },
+  {
+    "id": "phase_beam_upgrade",
+    "name": "Phase Beam Upgrade",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "phase_coolant_sigma",
+    "name": "Phase Coolant Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "phase_coolant_tau",
+    "name": "Phase Coolant Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "phase_coolant_theta",
+    "name": "Phase Coolant Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "photon_accelerator",
+    "name": "Photon Accelerator",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "photon_blast",
+    "name": "Photon Blast",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "photon_cannon",
+    "name": "Photon Cannon",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "photon_cannon_upgrade",
+    "name": "Photon Cannon Upgrade",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "photonix_core",
+    "name": "Photonix Core",
+    "platform": "ship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ship",
+      "utilities"
+    ]
+  },
+  {
+    "id": "photovoltaic_panel",
+    "name": "Photovoltaic Panel",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "photovoltaic_panel_frigate",
+    "name": "Photovoltaic Panel (Frigate)",
+    "platform": "frigate",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "frigate"
+    ]
+  },
+  {
+    "id": "pilyusha_mark_vi",
+    "name": "Pilyusha Mark VI",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "plasma_core_casing_v1",
+    "name": "Plasma Core Casing V1",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon"
+    ]
+  },
+  {
+    "id": "plasma_launcher",
+    "name": "Plasma Launcher",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "grenade"
+    ]
+  },
+  {
+    "id": "plasma_launcher_upgrade",
+    "name": "Plasma Launcher Upgrade",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "plasma_resonator",
+    "name": "Plasma Resonator",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "plasmatic_warp_injector",
+    "name": "Plasmatic Warp Injector",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "polyphonic_core",
+    "name": "Polyphonic Core",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "positron_ejector",
+    "name": "Positron Ejector",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "positron_ejector_atlas",
+    "name": "Positron Ejector (Atlas)",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "positron_ejector_coolant_sigma",
+    "name": "Positron Ejector Coolant Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "positron_ejector_coolant_tau",
+    "name": "Positron Ejector Coolant Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "positron_ejector_coolant_theta",
+    "name": "Positron Ejector Coolant Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "positron_ejector_damage_sigma",
+    "name": "Positron Ejector Damage Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "positron_ejector_damage_tau",
+    "name": "Positron Ejector Damage Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "positron_ejector_damage_theta",
+    "name": "Positron Ejector Damage Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "positron_ejector_fire_rate_sigma",
+    "name": "Positron Ejector Fire Rate Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "positron_ejector_fire_rate_tau",
+    "name": "Positron Ejector Fire Rate Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "positron_ejector_fire_rate_theta",
+    "name": "Positron Ejector Fire Rate Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "positron_ejector_upgrade",
+    "name": "Positron Ejector Upgrade",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "power_distributor",
+    "name": "Power Distributor",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "power_distributor_frigate",
+    "name": "Power Distributor (Frigate)",
+    "platform": "frigate",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "frigate"
+    ]
+  },
+  {
+    "id": "prayer_of_kaladeela_dedar",
+    "name": "Prayer of Kaladeela Dedar",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "precision_minotaur_laser",
+    "name": "Precision Minotaur Laser",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "pressure_chamber",
+    "name": "Pressure Chamber",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "pressure_chamber_frigate",
+    "name": "Pressure Chamber (Frigate)",
+    "platform": "frigate",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "frigate"
+    ]
+  },
+  {
+    "id": "pressure_membrane",
+    "name": "Pressure Membrane",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "protection_mesh",
+    "name": "Protection Mesh",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "health"
+    ]
+  },
+  {
+    "id": "pulse_engine",
+    "name": "Pulse Engine",
+    "platform": "propulsion",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "propulsion",
+      "interplanetary"
+    ]
+  },
+  {
+    "id": "pulse_engine_upgrade",
+    "name": "Pulse Engine Upgrade",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "pulse_engine"
+    ]
+  },
+  {
+    "id": "pulse_jet_sigma",
+    "name": "Pulse Jet Sigma",
+    "platform": "ship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ship",
+      "utilities"
+    ]
+  },
+  {
+    "id": "pulse_jet_tau",
+    "name": "Pulse Jet Tau",
+    "platform": "ship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ship",
+      "utilities"
+    ]
+  },
+  {
+    "id": "pulse_spitter",
+    "name": "Pulse Spitter",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool"
+    ]
+  },
+  {
+    "id": "pulse_spitter_atlas",
+    "name": "Pulse Spitter (Atlas)",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool"
+    ]
+  },
+  {
+    "id": "pulse_spitter_accuracy_sigma",
+    "name": "Pulse Spitter Accuracy Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "pulse_spitter"
+    ]
+  },
+  {
+    "id": "pulse_spitter_accuracy_tau",
+    "name": "Pulse Spitter Accuracy Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "pulse_spitter"
+    ]
+  },
+  {
+    "id": "pulse_spitter_accuracy_theta",
+    "name": "Pulse Spitter Accuracy Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "pulse_spitter"
+    ]
+  },
+  {
+    "id": "pulse_spitter_damage_sigma",
+    "name": "Pulse Spitter Damage Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "pulse_spitter"
+    ]
+  },
+  {
+    "id": "pulse_spitter_damage_tau",
+    "name": "Pulse Spitter Damage Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "pulse_spitter"
+    ]
+  },
+  {
+    "id": "pulse_spitter_damage_theta",
+    "name": "Pulse Spitter Damage Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "pulse_spitter"
+    ]
+  },
+  {
+    "id": "pulse_spitter_reload_sigma",
+    "name": "Pulse Spitter Reload Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "pulse_spitter"
+    ]
+  },
+  {
+    "id": "pulse_spitter_reload_tau",
+    "name": "Pulse Spitter Reload Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "pulse_spitter"
+    ]
+  },
+  {
+    "id": "pulse_spitter_reload_theta",
+    "name": "Pulse Spitter Reload Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "pulse_spitter"
+    ]
+  },
+  {
+    "id": "pulse_spitter_ricochet_module",
+    "name": "Pulse Spitter Ricochet Module",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "pulse_spitter_upgrade",
+    "name": "Pulse Spitter Upgrade",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "pulsing_heart",
+    "name": "Pulsing Heart",
+    "platform": "propulsion",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "propulsion",
+      "interplanetary"
+    ]
+  },
+  {
+    "id": "q_resonator",
+    "name": "Q-Resonator",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "qv6_r_lucid_clarity",
+    "name": "QV6-R Lucid Clarity",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "qw17_elevated_trace",
+    "name": "QW17 Elevated Trace",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "radar_amplifier",
+    "name": "Radar Amplifier",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "communications"
+    ]
+  },
+  {
+    "id": "radar_power_resonator",
+    "name": "Radar Power Resonator",
+    "platform": "exocraft",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exocraft",
+      "communications"
+    ]
+  },
+  {
+    "id": "radiation_deflector",
+    "name": "Radiation Deflector",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "radiation_deflector_next",
+    "name": "Radiation Deflector (NEXT)",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "radiation_deflector_sigma",
+    "name": "Radiation Deflector Sigma",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "radiation_deflector_tau",
+    "name": "Radiation Deflector Tau",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "radiation_deflector_theta",
+    "name": "Radiation Deflector Theta",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "radiation_leak",
+    "name": "Radiation Leak",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "radiation_protection_module",
+    "name": "Radiation Protection Module",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "hazard"
+    ]
+  },
+  {
+    "id": "radiation_protection_upgrade",
+    "name": "Radiation Protection Upgrade",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "radiation_protection"
+    ]
+  },
+  {
+    "id": "railshot_adaptor",
+    "name": "Railshot Adaptor",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "projectile"
+    ]
+  },
+  {
+    "id": "rangeboost_sigma",
+    "name": "RangeBoost Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "rangeboost_tau",
+    "name": "RangeBoost Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "rapidfire_sigma",
+    "name": "Rapidfire Sigma",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "projectile"
+    ]
+  },
+  {
+    "id": "rapidfire_tau",
+    "name": "Rapidfire Tau",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "projectile"
+    ]
+  },
+  {
+    "id": "rapidfire_theta",
+    "name": "Rapidfire Theta",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "projectile"
+    ]
+  },
+  {
+    "id": "reactor_core",
+    "name": "Reactor Core",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "subcomponent"
+    ]
+  },
+  {
+    "id": "reality_de_threader",
+    "name": "Reality De-Threader",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "rebound_grenades",
+    "name": "Rebound Grenades",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "grenade"
+    ]
+  },
+  {
+    "id": "rebound_grenades_tau",
+    "name": "Rebound Grenades Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "grenade"
+    ]
+  },
+  {
+    "id": "rebuilt_exosuit_module",
+    "name": "Rebuilt Exosuit Module",
+    "platform": "consumable",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "consumable",
+      "salvaged_upgrade_components"
+    ]
+  },
+  {
+    "id": "recoil_stabiliser_sigma",
+    "name": "Recoil Stabiliser Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "recoil_stabiliser_tau",
+    "name": "Recoil Stabiliser Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "recoil_stabiliser_theta",
+    "name": "Recoil Stabiliser Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "reflex_aspect_xi",
+    "name": "Reflex Aspect XI",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "reflex_elutisti",
+    "name": "Reflex Elutisti",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "reflex_thagrenbo_xopre",
+    "name": "Reflex Thagrenbo-Xopre",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "reload_accelerant_sigma",
+    "name": "Reload Accelerant Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "reload_accelerant_tau",
+    "name": "Reload Accelerant Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "reload_accelerant_theta",
+    "name": "Reload Accelerant Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "remembrance",
+    "name": "Remembrance",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "health"
+    ]
+  },
+  {
+    "id": "resonance_amplifier",
+    "name": "Resonance Amplifier",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "resonance_matrix",
+    "name": "Resonance Matrix",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "retort_of_ryforbag",
+    "name": "Retort of Ryforbag",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "return_of_otusiret_fuma",
+    "name": "Return of Otusiret-Fuma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "ricochet_sigma",
+    "name": "Ricochet Sigma",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "projectile"
+    ]
+  },
+  {
+    "id": "ricochet_tau",
+    "name": "Ricochet Tau",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "projectile"
+    ]
+  },
+  {
+    "id": "ricochet_theta",
+    "name": "Ricochet Theta",
+    "platform": "weapon",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "weapon",
+      "projectile"
+    ]
+  },
+  {
+    "id": "riposte_of_daukaint",
+    "name": "Riposte of Daukaint",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "riposte_of_issaphan",
+    "name": "Riposte of Issaphan",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "rocket_boots",
+    "name": "Rocket Boots",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "movement"
+    ]
+  },
+  {
+    "id": "rocket_launcher",
+    "name": "Rocket Launcher",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "rusted_circuits",
+    "name": "Rusted Circuits",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "rusted_power_core",
+    "name": "Rusted Power Core",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool"
+    ]
+  },
+  {
+    "id": "safety_panel",
+    "name": "Safety Panel",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "saline_carapace",
+    "name": "Saline Carapace",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "launch_thruster"
+    ]
+  },
+  {
+    "id": "salvaged_upgrade_components",
+    "name": "Salvaged Upgrade Components",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "scan_harmoniser",
+    "name": "Scan Harmoniser",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "scanner",
+    "name": "Scanner",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "scatter_blaster",
+    "name": "Scatter Blaster",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "scatter_blaster_accuracy_sigma",
+    "name": "Scatter Blaster Accuracy Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scatter_blaster"
+    ]
+  },
+  {
+    "id": "scatter_blaster_accuracy_tau",
+    "name": "Scatter Blaster Accuracy Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scatter_blaster"
+    ]
+  },
+  {
+    "id": "scatter_blaster_accuracy_theta",
+    "name": "Scatter Blaster Accuracy Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scatter_blaster"
+    ]
+  },
+  {
+    "id": "scatter_blaster_capacity_sigma",
+    "name": "Scatter Blaster Capacity Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scatter_blaster"
+    ]
+  },
+  {
+    "id": "scatter_blaster_capacity_tau",
+    "name": "Scatter Blaster Capacity Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scatter_blaster"
+    ]
+  },
+  {
+    "id": "scatter_blaster_capacity_theta",
+    "name": "Scatter Blaster Capacity Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scatter_blaster"
+    ]
+  },
+  {
+    "id": "scatter_blaster_damage_sigma",
+    "name": "Scatter Blaster Damage Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scatter_blaster"
+    ]
+  },
+  {
+    "id": "scatter_blaster_damage_tau",
+    "name": "Scatter Blaster Damage Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scatter_blaster"
+    ]
+  },
+  {
+    "id": "scatter_blaster_damage_theta",
+    "name": "Scatter Blaster Damage Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scatter_blaster"
+    ]
+  },
+  {
+    "id": "scatter_blaster_reload_sigma",
+    "name": "Scatter Blaster Reload Sigma",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scatter_blaster"
+    ]
+  },
+  {
+    "id": "scatter_blaster_reload_tau",
+    "name": "Scatter Blaster Reload Tau",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scatter_blaster"
+    ]
+  },
+  {
+    "id": "scatter_blaster_reload_theta",
+    "name": "Scatter Blaster Reload Theta",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scatter_blaster"
+    ]
+  },
+  {
+    "id": "scatter_blaster_upgrade",
+    "name": "Scatter Blaster Upgrade",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "scorched_plating",
+    "name": "Scorched Plating",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "scream_suppressor",
+    "name": "Scream Suppressor",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "shield"
+    ]
+  },
+  {
+    "id": "security_alarm",
+    "name": "Security Alarm",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "self_greasing_servos",
+    "name": "Self-Greasing Servos",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle",
+      "minotaur"
+    ]
+  },
+  {
+    "id": "sentinel_exosuit_fragment",
+    "name": "Sentinel Exosuit Fragment",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "consumable"
+    ]
+  },
+  {
+    "id": "sentinel_weapons_shard",
+    "name": "Sentinel Weapons Shard",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "consumable"
+    ]
+  },
+  {
+    "id": "servo_arm",
+    "name": "Servo Arm",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "servo_arm_frigate",
+    "name": "Servo Arm (Frigate)",
+    "platform": "frigate",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "frigate"
+    ]
+  },
+  {
+    "id": "shadow_of_eharasaki",
+    "name": "Shadow of Eharasaki",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "shattered_bulwark",
+    "name": "Shattered Bulwark",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "shattered_power_core",
+    "name": "Shattered Power Core",
+    "platform": "drop_pod",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "drop_pod"
+    ]
+  },
+  {
+    "id": "shell_greaser",
+    "name": "Shell Greaser",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "shield_kinetics",
+    "name": "Shield Kinetics",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "health"
+    ]
+  },
+  {
+    "id": "shield_lattice",
+    "name": "Shield Lattice",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "hazard"
+    ]
+  },
+  {
+    "id": "shieldboost_sigma",
+    "name": "ShieldBoost Sigma",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "shieldboost_tau",
+    "name": "ShieldBoost Tau",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "shieldboost_theta",
+    "name": "ShieldBoost Theta",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "shieldboost_v1",
+    "name": "ShieldBoost V1",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "short_circuit",
+    "name": "Short Circuit",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool"
+    ]
+  },
+  {
+    "id": "shortburst_adaptor",
+    "name": "Shortburst Adaptor",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "simple_translator",
+    "name": "Simple Translator",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "singular_angle_xvii",
+    "name": "Singular Angle XVII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "singularity_cortex",
+    "name": "Singularity Cortex",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "singularity_engine",
+    "name": "Singularity Engine",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "solar_ray",
+    "name": "Solar Ray",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "solenoid",
+    "name": "Solenoid",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "solenoid_frigate",
+    "name": "Solenoid (Frigate)",
+    "platform": "frigate",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "frigate"
+    ]
+  },
+  {
+    "id": "spawning_sac",
+    "name": "Spawning Sac",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "inventory"
+    ]
+  },
+  {
+    "id": "spewing_vents",
+    "name": "Spewing Vents",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "weapons"
+    ]
+  },
+  {
+    "id": "spring_casing",
+    "name": "Spring Casing",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "spurushko_mark_iv",
+    "name": "Spurushko Mark IV",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "stable_iguenowah_ropes",
+    "name": "Stable Iguenowah-Ropes",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "stable_retort_xii",
+    "name": "Stable Retort XII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "stamina_enhancement_sigma",
+    "name": "Stamina Enhancement Sigma",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "stamina"
+    ]
+  },
+  {
+    "id": "stamina_enhancement_tau",
+    "name": "Stamina Enhancement Tau",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "stamina"
+    ]
+  },
+  {
+    "id": "stamina_enhancement_theta",
+    "name": "Stamina Enhancement Theta",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "stamina"
+    ]
+  },
+  {
+    "id": "star_seed",
+    "name": "Star Seed",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "health"
+    ]
+  },
+  {
+    "id": "steady_udyonkin_enti",
+    "name": "Steady Udyonkin-Enti",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "strange_gift_iv",
+    "name": "Strange Gift IV",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "strange_insight_viii",
+    "name": "Strange Insight VIII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "sub_light_amplifier",
+    "name": "Sub-Light Amplifier",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "interplanetary"
+    ]
+  },
+  {
+    "id": "subdued_concept_ix",
+    "name": "Subdued Concept IX",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "sublime_gleam_iii",
+    "name": "Sublime Gleam III",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "sublime_riposte_vi",
+    "name": "Sublime Riposte VI",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "suchinohe_mark_x",
+    "name": "Suchinohe Mark X",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "sukaiwak_exceptional",
+    "name": "Sukaiwak Exceptional",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "rifle"
+    ]
+  },
+  {
+    "id": "superconductive_lock",
+    "name": "Superconductive Lock",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "superior_translator",
+    "name": "Superior Translator",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "survey_device",
+    "name": "Survey Device",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "tamper_prevention_device",
+    "name": "Tamper Prevention Device",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "teleport_receiver",
+    "name": "Teleport Receiver",
+    "platform": "ship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "ship"
+    ]
+  },
+  {
+    "id": "temporal_warp_computer",
+    "name": "Temporal Warp Computer",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "terrain_manipulator",
+    "name": "Terrain Manipulator",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "tool"
+    ]
+  },
+  {
+    "id": "tethys_beam",
+    "name": "Tethys Beam",
+    "platform": "aquatic",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "aquatic"
+    ]
+  },
+  {
+    "id": "tetmalont_mark_vi",
+    "name": "Tetmalont Mark VI",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_acmiinar_b600",
+    "name": "The Acmiinar B600",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_auristinc_taed_k200",
+    "name": "The Auristinc-Taed K200",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_ayborodu_v0_28",
+    "name": "The Ayborodu V0.28",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_bawilotag_v5_30",
+    "name": "The Bawilotag v5.30",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_bujunman_x400",
+    "name": "The Bujunman X400",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "compact"
+    ]
+  },
+  {
+    "id": "the_giumelbu_baxa_v4_10",
+    "name": "The Giumelbu Baxa v4.10",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_guchihama_v8_17",
+    "name": "The Guchihama v8.17",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_hefeichac_duan_u200",
+    "name": "The Hefeichac Duan U200",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_hughnava_b300",
+    "name": "The Hughnava B300",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_ijonanko_uiet_u100",
+    "name": "The Ijonanko-Uiet U100",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_isrankan_v6_11",
+    "name": "The Isrankan v6.11",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_issinggas_coyli_j600",
+    "name": "The Issinggas Coyli J600",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_mepushpoo_v5_4",
+    "name": "The Mepushpoo v5.4",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_natlinmi_inzu_y200",
+    "name": "The Natlinmi Inzu Y200",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_ouwerkpa_n300",
+    "name": "The Ouwerkpa N300",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_ripugand_t600",
+    "name": "The Ripugand T600",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_rulsefren_terq_d600",
+    "name": "The Rulsefren-Terq D600",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_runinsko_v1_12",
+    "name": "The Runinsko v1.12",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_selmikka_tosu_v6_28",
+    "name": "The Selmikka-Tosu v6.28",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_t400",
+    "name": "The T400",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_teskaurvoy_b700",
+    "name": "The Teskaurvoy B700",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_totzerid_t600",
+    "name": "The Totzerid T600",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "the_utyannwin_v6_7",
+    "name": "The Utyannwin v6.7",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "theory_of_ivkativa",
+    "name": "Theory of Ivkativa",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "theory_of_yoncoraba_aodi",
+    "name": "Theory of Yoncoraba Aodi",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "thermal_buffer",
+    "name": "Thermal Buffer",
+    "platform": "vehicle",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "vehicle"
+    ]
+  },
+  {
+    "id": "thermal_protection_module_cold",
+    "name": "Thermal Protection Module (Cold)",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "hazard"
+    ]
+  },
+  {
+    "id": "thermal_protection_module_heat",
+    "name": "Thermal Protection Module (Heat)",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "hazard"
+    ]
+  },
+  {
+    "id": "thermal_protection_upgrade_cold",
+    "name": "Thermal Protection Upgrade (Cold)",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "thermal_protection"
+    ]
+  },
+  {
+    "id": "thermal_protection_upgrade_heat",
+    "name": "Thermal Protection Upgrade (Heat)",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "thermal_protection"
+    ]
+  },
+  {
+    "id": "thermic_layer",
+    "name": "Thermic Layer",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "thermic_layer_next",
+    "name": "Thermic Layer (NEXT)",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "thermic_layer_sigma",
+    "name": "Thermic Layer Sigma",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "thermic_layer_tau",
+    "name": "Thermic Layer Tau",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "thermic_layer_theta",
+    "name": "Thermic Layer Theta",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "thermoregulator",
+    "name": "Thermoregulator",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "thermoregulator_frigate",
+    "name": "Thermoregulator (Frigate)",
+    "platform": "frigate",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "frigate"
+    ]
+  },
+  {
+    "id": "tiny_motor",
+    "name": "Tiny Motor",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "tiny_motor_frigate",
+    "name": "Tiny Motor (Frigate)",
+    "platform": "frigate",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "frigate"
+    ]
+  },
+  {
+    "id": "toxic_protection_module",
+    "name": "Toxic Protection Module",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "hazard"
+    ]
+  },
+  {
+    "id": "toxic_protection_upgrade",
+    "name": "Toxic Protection Upgrade",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "hazard"
+    ]
+  },
+  {
+    "id": "toxin_suppressor",
+    "name": "Toxin Suppressor",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "hazard"
+    ]
+  },
+  {
+    "id": "toxin_suppressor_next",
+    "name": "Toxin Suppressor (NEXT)",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "toxin_suppressor_sigma",
+    "name": "Toxin Suppressor Sigma",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "toxin_suppressor_tau",
+    "name": "Toxin Suppressor Tau",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "toxin_suppressor_theta",
+    "name": "Toxin Suppressor Theta",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "utilities"
+    ]
+  },
+  {
+    "id": "trade_rocket",
+    "name": "Trade Rocket",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit"
+    ]
+  },
+  {
+    "id": "transmission_box",
+    "name": "Transmission Box",
+    "platform": "point_of_interest",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "point_of_interest"
+    ]
+  },
+  {
+    "id": "transmission_box_frigate",
+    "name": "Transmission Box (Frigate)",
+    "platform": "frigate",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "frigate"
+    ]
+  },
+  {
+    "id": "trident_key_damaged_component",
+    "name": "Trident Key (Damaged Component)",
+    "platform": "artifact",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "artifact"
+    ]
+  },
+  {
+    "id": "ubeijiao_mark_v",
+    "name": "Ubeijiao Mark V",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "uitaakis_mark_ix",
+    "name": "Uitaakis Mark IX",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "ummerukam_mark_xviii",
+    "name": "Ummerukam Mark XVIII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "underwater_oxygen_upgrade",
+    "name": "Underwater Oxygen Upgrade",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "aeration_membrane"
+    ]
+  },
+  {
+    "id": "underwater_protection_module",
+    "name": "Underwater Protection Module",
+    "platform": "exosuit",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "exosuit",
+      "hazard"
+    ]
+  },
+  {
+    "id": "unusual_ovetskaye_vexi",
+    "name": "Unusual Ovetskaye-Vexi",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "urbashyo_laeu_mark_xi",
+    "name": "Urbashyo-Laeu Mark XI",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "urihonma_mark_ii",
+    "name": "Urihonma Mark II",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "v_13q_vivid_theory",
+    "name": "V/13Q Vivid Theory",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "vesper_sail",
+    "name": "Vesper Sail",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "vivid_lusonhistr",
+    "name": "Vivid Lusonhistr",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "voltaic_amplifier",
+    "name": "Voltaic Amplifier",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "w_q_obscured_angle",
+    "name": "W-Q Obscured Angle",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "warp_core_resonator",
+    "name": "Warp Core Resonator",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "warp_reactor_sigma",
+    "name": "Warp Reactor Sigma",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "warp_reactor_tau",
+    "name": "Warp Reactor Tau",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "warp_reactor_theta",
+    "name": "Warp Reactor Theta",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "warp_shielding_sigma",
+    "name": "Warp Shielding Sigma",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "warp_shielding_tau",
+    "name": "Warp Shielding Tau",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "warp_shielding_theta",
+    "name": "Warp Shielding Theta",
+    "platform": "freighter",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "freighter",
+      "hyperdrive"
+    ]
+  },
+  {
+    "id": "waveform_engine",
+    "name": "Waveform Engine",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship"
+    ]
+  },
+  {
+    "id": "waveform_oscillator",
+    "name": "Waveform Oscillator",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapons"
+    ]
+  },
+  {
+    "id": "waveform_recycler",
+    "name": "Waveform Recycler",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "scanner"
+    ]
+  },
+  {
+    "id": "widebeam_adaptor",
+    "name": "Widebeam Adaptor",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "laser"
+    ]
+  },
+  {
+    "id": "widebeam_adaptor_v1",
+    "name": "Widebeam Adaptor V1",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "laser"
+    ]
+  },
+  {
+    "id": "wideshot_adaptor",
+    "name": "Wideshot Adaptor",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "projectile"
+    ]
+  },
+  {
+    "id": "wormhole_brain",
+    "name": "Wormhole Brain",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "scanner"
+    ]
+  },
+  {
+    "id": "wormhole_brain_implant",
+    "name": "Wormhole Brain Implant",
+    "platform": "starship",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "starship",
+      "scanner"
+    ]
+  },
+  {
+    "id": "yazzioss_mark_xvii",
+    "name": "Yazzioss Mark XVII",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
+  },
+  {
+    "id": "zihurikha_mark_iv",
+    "name": "Zihurikha Mark IV",
+    "platform": "multi_tool",
+    "slotType": "tech",
+    "baseValue": 1,
+    "adjacency": {},
+    "superchargeMultiplier": 1,
+    "tags": [
+      "multi_tool",
+      "weapon"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- add a sync script that pulls item, refiner, cooking, and technology data from the No Man's Sky wiki
- expose the sync workflow through an npm script for easy regeneration
- refresh the items, refiner, cooking, and tech datasets with the wiki export

## Testing
- npm run validate:data

------
https://chatgpt.com/codex/tasks/task_e_68e0963a6c2c8321a62f0939f8a9c0f7