### PR TITLE
Enhance refiner page with resource icons and new font

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,13 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+@font-face {
+  font-family: 'NMSGeoSans_Kerned';
+  src: url('./assets/NMSGeoSans_Kerned.tff') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
 :root {
   color-scheme: dark;
 }
 
 body {
   @apply bg-surface text-slate-100 min-h-screen;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: 'NMSGeoSans_Kerned', 'Inter', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
 }
 
 a {


### PR DESCRIPTION
## Summary
- load resource icon assets and surface them alongside refiner inputs and outputs
- improve the refiner table layout with icon-aware cells and fallbacks
- register the NMSGeoSans_Kerned font for global typography

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68e2fc5a3bc08321bf2fb42e2b033bca