### PR TITLE
Use hosted NMS Futura font for global typography

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,14 +1,8 @@
+@import url('https://font.nmscd.com/assets/font/NMSFuturaProBook_Kerned/Web-TT/NMSFuturaProBook_Kerned.css');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@font-face {
-  font-family: 'NMSGeoSans_Kerned';
-  src: url('./assets/NMSGeoSans_Kerned.tff') format('truetype');
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
 
 :root {
   color-scheme: dark;
@@ -16,7 +10,7 @@
 
 body {
   @apply bg-surface text-slate-100 min-h-screen;
-  font-family: 'NMSGeoSans_Kerned', 'Inter', system-ui, -apple-system, BlinkMacSystemFont,
+  font-family: 'NMSFuturaProBook', 'Inter', system-ui, -apple-system, BlinkMacSystemFont,
     'Segoe UI', sans-serif;
 }
 


### PR DESCRIPTION
## Summary
- load the NMS Futura Pro Book font from the hosted stylesheet for GitHub Pages
- apply the new font family across the app body styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30148dfac8321969b0467c0d31248