### PR TITLE
Add resource icons to crafting tab

### DIFF
--- a/src/components/ResourceIcon.tsx
+++ b/src/components/ResourceIcon.tsx
@@ -1,0 +1,38 @@
+import { clsx } from 'clsx'
+import type { ReactElement } from 'react'
+
+interface ResourceIconProps {
+  iconSrc?: string
+  label: string
+  className?: string
+}
+
+export const ResourceIcon = ({ iconSrc, label, className }: ResourceIconProps): ReactElement => {
+  const sizeClass = className ?? 'h-12 w-12'
+
+  if (iconSrc) {
+    return (
+      <img
+        src={iconSrc}
+        alt={`${label} icon`}
+        loading="lazy"
+        className={clsx(
+          'shrink-0 rounded-full border border-slate-700 bg-surface/80 object-contain p-1 shadow-inner',
+          sizeClass
+        )}
+      />
+    )
+  }
+
+  return (
+    <div
+      className={clsx(
+        'flex shrink-0 items-center justify-center rounded-full border border-slate-700 bg-surface/60 text-xs uppercase tracking-wide text-slate-500',
+        sizeClass
+      )}
+    >
+      {label.slice(0, 2).toUpperCase()}
+    </div>
+  )
+}
+

--- a/src/lib/resourceIcons.ts
+++ b/src/lib/resourceIcons.ts
@@ -1,0 +1,66 @@
+import type { Item } from '../types'
+
+type ResourceDescriptor = Pick<Item, 'id' | 'name'> | { id?: string; name?: string }
+
+const resourceIconModules = import.meta.glob('../assets/resources/*.{png,jpg,jpeg,webp,svg}', {
+  eager: true,
+  import: 'default'
+}) as Record<string, string>
+
+const sanitizeKey = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+
+const resourceIconMap = new Map<string, string>()
+
+Object.entries(resourceIconModules).forEach(([path, src]) => {
+  const fileName = path.split('/').pop() ?? ''
+  const baseName = fileName.replace(/\.[^/.]+$/, '')
+  const variations = new Set<string>([
+    baseName.toLowerCase(),
+    sanitizeKey(baseName),
+    sanitizeKey(baseName).replace(/_/g, '')
+  ])
+
+  variations.forEach((key) => {
+    if (key) {
+      resourceIconMap.set(key, src)
+    }
+  })
+})
+
+const normalizeDescriptor = (descriptor: ResourceDescriptor): string[] => {
+  const values: string[] = []
+
+  if ('id' in descriptor && descriptor.id) {
+    values.push(descriptor.id)
+  }
+
+  if ('name' in descriptor && descriptor.name) {
+    values.push(descriptor.name)
+  }
+
+  return values
+}
+
+export const getResourceIcon = (descriptor: ResourceDescriptor): string | undefined => {
+  const candidates = normalizeDescriptor(descriptor).flatMap((value) => {
+    const normalized = value.trim()
+    if (!normalized) return []
+    const sanitized = sanitizeKey(normalized)
+    return [normalized.toLowerCase(), sanitized, sanitized.replace(/_/g, '')]
+  })
+
+  for (const key of candidates) {
+    if (!key) continue
+    const match = resourceIconMap.get(key)
+    if (match) {
+      return match
+    }
+  }
+
+  return undefined
+}
+

--- a/src/pages/Crafting.tsx
+++ b/src/pages/Crafting.tsx
@@ -1,7 +1,9 @@
+import { clsx } from 'clsx'
 import { useMemo, useState } from 'react'
+import { ResourceIcon } from '../components/ResourceIcon'
+import { getResourceIcon } from '../lib/resourceIcons'
 import { useAppStore } from '../store/useAppStore'
 import type { CraftingRecipe, Item } from '../types'
-import { clsx } from 'clsx'
 
 interface RequirementEntry {
   item: Item
@@ -102,6 +104,7 @@ const Crafting = (): JSX.Element => {
           const have = haveMap[component.item] ?? 0
           const need = Math.max(totalQty - have, 0)
           const value = (item?.value ?? 0) * totalQty
+          const icon = getResourceIcon({ id: component.item, name: label })
 
           return (
             <li
@@ -109,7 +112,10 @@ const Crafting = (): JSX.Element => {
               className="rounded border border-slate-700 bg-surface/60 p-3 text-sm text-slate-200"
             >
               <div className="flex flex-wrap items-center justify-between gap-3">
-                <span className="font-medium">{label}</span>
+                <div className="flex items-center gap-3">
+                  <ResourceIcon iconSrc={icon} label={label} className="h-10 w-10" />
+                  <span className="font-medium">{label}</span>
+                </div>
                 <span className="text-xs text-slate-400">{value.toLocaleString()} units value</span>
               </div>
               <div className="mt-2 grid gap-2 text-xs text-slate-300 sm:grid-cols-3">
@@ -160,15 +166,19 @@ const Crafting = (): JSX.Element => {
                   {aggregateRequirements.map(({ item, required }) => {
                     const have = haveMap[item.id] ?? 0
                     const need = Math.max(required - have, 0)
+                    const icon = getResourceIcon(item)
                     return (
                       <div
                         key={`agg-${item.id}`}
                         className={clsx(
-                          'flex flex-col gap-1 rounded border border-slate-700 px-3 py-2 text-sm',
+                          'flex flex-col gap-2 rounded border border-slate-700 px-3 py-2 text-sm',
                           need > 0 ? 'bg-surface/60 text-slate-200' : 'bg-surface/40 text-slate-400'
                         )}
                       >
-                        <span className="font-medium">{item.name}</span>
+                        <div className="flex items-center gap-3">
+                          <ResourceIcon iconSrc={icon} label={item.name} className="h-10 w-10" />
+                          <span className="font-medium">{item.name}</span>
+                        </div>
                         <div className="flex items-center justify-between text-xs text-slate-400">
                           <span>Required {required}</span>
                           <span>Need {need}</span>

--- a/src/pages/Refiner.tsx
+++ b/src/pages/Refiner.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from 'react'
 import { useMemo, useState } from 'react'
+import { ResourceIcon } from '../components/ResourceIcon'
+import { getResourceIcon } from '../lib/resourceIcons'
 import { useAppStore } from '../store/useAppStore'
 import type { Item } from '../types'
 
@@ -16,52 +18,6 @@ interface DecoratedRecipe {
   output: DecoratedInput
   timeSeconds: number
   searchText: string
-}
-
-const resourceIconModules = import.meta.glob('../assets/resources/*.{png,jpg,jpeg,webp,svg}', {
-  eager: true,
-  import: 'default'
-}) as Record<string, string>
-
-const sanitizeKey = (value: string): string =>
-  value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-
-const resourceIconMap = new Map<string, string>()
-
-Object.entries(resourceIconModules).forEach(([path, src]) => {
-  const fileName = path.split('/').pop() ?? ''
-  const baseName = fileName.replace(/\.[^/.]+$/, '')
-  const variations = new Set<string>([
-    baseName.toLowerCase(),
-    sanitizeKey(baseName),
-    sanitizeKey(baseName).replace(/_/g, '')
-  ])
-  variations.forEach((key) => {
-    if (key) {
-      resourceIconMap.set(key, src)
-    }
-  })
-})
-
-const getResourceIcon = (item: DecoratedInput): string | undefined => {
-  const candidates = [
-    item.id.toLowerCase(),
-    sanitizeKey(item.id),
-    sanitizeKey(item.id).replace(/_/g, ''),
-    sanitizeKey(item.name),
-    sanitizeKey(item.name).replace(/_/g, '')
-  ]
-  for (const key of candidates) {
-    if (!key) continue
-    const match = resourceIconMap.get(key)
-    if (match) {
-      return match
-    }
-  }
-  return undefined
 }
 
 const fallbackName = (itemId: string): string =>
@@ -86,18 +42,7 @@ const ItemCell = ({
 
   return (
     <div className="flex items-start gap-3">
-      {icon ? (
-        <img
-          src={icon}
-          alt={`${item.name} icon`}
-          loading="lazy"
-          className="h-12 w-12 shrink-0 rounded-full border border-slate-700 bg-surface/80 object-contain p-1 shadow-inner"
-        />
-      ) : (
-        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-slate-700 bg-surface/60 text-xs uppercase tracking-wide text-slate-500">
-          {item.name.slice(0, 2).toUpperCase()}
-        </div>
-      )}
+      <ResourceIcon iconSrc={icon} label={item.name} />
       <div className="space-y-0.5">
         <p className={emphasize ? 'font-semibold text-primary' : 'font-medium text-slate-100'}>
           {item.name}


### PR DESCRIPTION
## Summary
- add a shared resource icon map and display component for in-game items
- show icons for crafting shopping list entries and component breakdowns
- refactor the refiner view to use the shared icon component

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68e30935e4f48321939925d45fbf82ac